### PR TITLE
refactor: replace loguru with python logging in version bumping script

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -6,12 +6,13 @@ Handles version bumping for both Python (src/expenses_counter/__init__.py) and J
 
 import argparse
 import json
+import logging
 import re
 import sys
 from pathlib import Path
 from typing import Tuple
 
-from loguru import logger
+logger = logging.getLogger(__name__)
 
 
 def parse_version(version_string: str) -> Tuple[int, int, int]:


### PR DESCRIPTION
This pull request makes a minor update to the logging approach in `.github/scripts/bump_version.py`, switching from the `loguru` logging library to Python's built-in `logging` module for consistency and reduced dependencies.