### PR TITLE
Fix config in main

### DIFF
--- a/backend/src/expenses_counter/__init__.py
+++ b/backend/src/expenses_counter/__init__.py
@@ -1,3 +1,3 @@
 """Expenses counter package."""
 
-__version__ = "1.0.12"
+__version__ = "1.0.13"

--- a/backend/src/expenses_counter/__main__.py
+++ b/backend/src/expenses_counter/__main__.py
@@ -23,9 +23,9 @@ def main():
 
     uvicorn.run(
         app,
-        host="0.0.0.0",
-        port=config.app_port,
-        log_level=config.app_log_level.lower(),
+        host=config.info.api_info.host,
+        port=config.info.api_info.app_port,
+        log_level=config.info.api_info.log_level.lower(),
     )
 
 

--- a/backend/src/expenses_counter/config/models/info/api.py
+++ b/backend/src/expenses_counter/config/models/info/api.py
@@ -17,6 +17,7 @@ class APIInfo(BaseModel):
     logging level for application logs.
 
     Attributes:
+        host: The host of the application. Defaults to "0.0.0.0".
         app_port: The TCP port number on which the API server listens for
             incoming connections. This is a required field.
         debug: Whether to run the application in debug mode. Debug mode
@@ -35,6 +36,7 @@ class APIInfo(BaseModel):
 
     """
 
+    host: str = Field("0.0.0.0", description="The host of the application")
     app_port: int = Field(..., description="The port of the application")
     debug: bool = Field(False, description="The debug mode of the application")
     log_level: str = Field("INFO", description="The log level of the application")


### PR DESCRIPTION
This pull request updates how the API server's host, port, and log level are configured, moving these settings into the `APIInfo` configuration model for better organization and flexibility. The most important changes are:

**Configuration Model Updates:**

* Added a new `host` field to the `APIInfo` model in `backend/src/expenses_counter/config/models/info/api.py`, with a default value of `"0.0.0.0"` and an updated class docstring to document this field. [[1]](diffhunk://#diff-2deb5e90a5122facd839ad17b3077ea48d8b2a36465c7ff79e4279221141b290R20) [[2]](diffhunk://#diff-2deb5e90a5122facd839ad17b3077ea48d8b2a36465c7ff79e4279221141b290R39)

**Application Startup Changes:**

* Updated the `uvicorn.run` call in `backend/src/expenses_counter/__main__.py` to use the new `host`, `app_port`, and `log_level` fields from `config.info.api_info`, instead of the previous top-level config fields.