### PR TITLE
feat: Add async click

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "alembic>=1.17.2",
     "asyncpg>=0.31.0",
     "beautifulsoup4>=4.14.3",
-    "click>=8.3.0",
     "django>=5.2.7",
     "djangorestframework>=3.16.1",
     "fastapi>=0.120.4",
@@ -41,6 +40,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "asyncclick>=8.3.0.7",
     "httpx>=0.28.1",
     "ipykernel>=7.1.0",
     "pandas>=2.3.3",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ requires-python = ">=3.13"
 dependencies = [
     "aiosqlite>=0.21.0",
     "alembic>=1.17.2",
+    "asyncclick>=8.3.0.7",
     "asyncpg>=0.31.0",
     "beautifulsoup4>=4.14.3",
     "django>=5.2.7",
@@ -40,7 +41,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "asyncclick>=8.3.0.7",
     "httpx>=0.28.1",
     "ipykernel>=7.1.0",
     "pandas>=2.3.3",

--- a/backend/src/expenses_counter/utils/cli/crawler.py
+++ b/backend/src/expenses_counter/utils/cli/crawler.py
@@ -2,15 +2,13 @@
 
 __all__ = ("crawler",)
 
-import asyncio
-
-import click
+import asyncclick as click
 
 from expenses_counter.commands.crawl_url import CrawlAndCreateCommand
 
 
 @click.group(help="Crawler commands")
-def crawler():
+async def crawler():
     """Crawler commands."""
     pass
 
@@ -18,13 +16,9 @@ def crawler():
 @crawler.command(help="Crawl and create transaction")
 @click.option("--url", help="URL to crawl", required=True)
 @click.option("--default-category-id", help="Default category ID", type=int, required=False, default=None)
-def crawl_and_create(url: str, default_category_id: int | None):
+async def crawl_and_create(url: str, default_category_id: int | None):
     """Crawl and create transaction."""
-
-    async def create():
-        command = CrawlAndCreateCommand(url=url, default_category_id=default_category_id)
-        await command.initialize()
-        await command.validate()
-        await command.execute()
-
-    asyncio.run(create())
+    command = CrawlAndCreateCommand(url=url, default_category_id=default_category_id)
+    await command.initialize()
+    await command.validate()
+    await command.execute()

--- a/backend/src/expenses_counter/utils/cli/main.py
+++ b/backend/src/expenses_counter/utils/cli/main.py
@@ -40,7 +40,7 @@ async def show_config(ctx: click.Context) -> None:
 @click.option("--host", default="0.0.0.0", help="Host to bind the server to.")
 @click.option("--port", default=3000, help="Port to bind the server to.")
 @click.option("--reload", is_flag=True, help="Enable auto-reload for development.")
-async def run(host: str, port: int, reload: bool) -> None:
+def run(host: str, port: int, reload: bool) -> None:
     """Start the Expenses Counter web server using Uvicorn.
 
     Launches the FastAPI application server with the specified configuration.
@@ -57,15 +57,13 @@ async def run(host: str, port: int, reload: bool) -> None:
 
     """
     click.echo(f"Starting Expenses Counter on {host}:{port} (reload={reload})")
-    config = uvicorn.Config(
+    uvicorn.run(
         "expenses_counter.modules.app:get_app",
         host=host,
         port=port,
         reload=reload,
         factory=True,
     )
-    server = uvicorn.Server(config)
-    await server.serve()
 
 
 main.add_command(crawler)

--- a/backend/src/expenses_counter/utils/cli/main.py
+++ b/backend/src/expenses_counter/utils/cli/main.py
@@ -1,4 +1,4 @@
-import click
+import asyncclick as click
 import uvicorn
 
 from expenses_counter import __version__ as app_version
@@ -10,7 +10,7 @@ from .crawler import crawler
 @click.group(help="CLI for managing the Expenses Counter.")
 @click.version_option(app_version, "-v", "--version", message=f"Expenses Counter, version {app_version}")
 @click.pass_context
-def main(ctx: click.Context) -> None:
+async def main(ctx: click.Context) -> None:
     """Initialize the main CLI group for the Expenses Counter.
 
     This function serves as the root command group for all CLI operations.
@@ -30,7 +30,7 @@ def main(ctx: click.Context) -> None:
 
 @main.command(help="Run the Expenses Counter application server.")
 @click.pass_context
-def show_config(ctx: click.Context) -> None:
+async def show_config(ctx: click.Context) -> None:
     """Show the Expenses Counter application configuration."""
     config: AppConfig = ctx.obj["config"]
     click.echo(config.model_dump_json(indent=2))
@@ -40,7 +40,7 @@ def show_config(ctx: click.Context) -> None:
 @click.option("--host", default="0.0.0.0", help="Host to bind the server to.")
 @click.option("--port", default=3000, help="Port to bind the server to.")
 @click.option("--reload", is_flag=True, help="Enable auto-reload for development.")
-def run(host: str, port: int, reload: bool) -> None:
+async def run(host: str, port: int, reload: bool) -> None:
     """Start the Expenses Counter web server using Uvicorn.
 
     Launches the FastAPI application server with the specified configuration.
@@ -57,13 +57,15 @@ def run(host: str, port: int, reload: bool) -> None:
 
     """
     click.echo(f"Starting Expenses Counter on {host}:{port} (reload={reload})")
-    uvicorn.run(
+    config = uvicorn.Config(
         "expenses_counter.modules.app:get_app",
         host=host,
         port=port,
         reload=reload,
         factory=True,
     )
+    server = uvicorn.Server(config)
+    await server.serve()
 
 
 main.add_command(crawler)

--- a/backend/src/expenses_counter/utils/cli/main.py
+++ b/backend/src/expenses_counter/utils/cli/main.py
@@ -28,7 +28,7 @@ async def main(ctx: click.Context) -> None:
     ctx.obj["config"] = AppConfig.get_or_create()
 
 
-@main.command(help="Run the Expenses Counter application server.")
+@main.command(help="Show the Expenses Counter application configuration.")
 @click.pass_context
 async def show_config(ctx: click.Context) -> None:
     """Show the Expenses Counter application configuration."""
@@ -36,7 +36,7 @@ async def show_config(ctx: click.Context) -> None:
     click.echo(config.model_dump_json(indent=2))
 
 
-@main.command(help="Run the Expenses Counter application server.")
+@main.command(help="Start the Expenses Counter application server.")
 @click.option("--host", default="0.0.0.0", help="Host to bind the server to.")
 @click.option("--port", default=3000, help="Port to bind the server to.")
 @click.option("--reload", is_flag=True, help="Enable auto-reload for development.")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -405,6 +405,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "asyncclick" },
     { name = "asyncpg" },
     { name = "beautifulsoup4" },
     { name = "django" },
@@ -425,7 +426,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "asyncclick" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "pandas" },
@@ -440,6 +440,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "alembic", specifier = ">=1.17.2" },
+    { name = "asyncclick", specifier = ">=8.3.0.7" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "django", specifier = ">=5.2.7" },
@@ -460,7 +461,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "asyncclick", specifier = ">=8.3.0.7" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "ipykernel", specifier = ">=7.1.0" },
     { name = "pandas", specifier = ">=2.3.3" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -87,6 +87,18 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncclick"
+version = "8.3.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/ca/25e426d16bd0e91c1c9259112cecd17b2c2c239bdd8e5dba430f3bd5e3ef/asyncclick-8.3.0.7.tar.gz", hash = "sha256:8a80d8ac613098ee6a9a8f0248f60c66c273e22402cf3f115ed7f071acfc71d3", size = 277634, upload-time = "2025-10-11T08:35:44.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/d9/782ffcb4c97b889bc12d8276637d2739b99520390ee8fec77c07416c5d12/asyncclick-8.3.0.7-py3-none-any.whl", hash = "sha256:7607046de39a3f315867cad818849f973e29d350c10d92f251db3ff7600c6c7d", size = 109925, upload-time = "2025-10-11T08:35:43.378Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -395,7 +407,6 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "beautifulsoup4" },
-    { name = "click" },
     { name = "django" },
     { name = "djangorestframework" },
     { name = "fastapi" },
@@ -414,6 +425,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "asyncclick" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "pandas" },
@@ -430,7 +442,6 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.17.2" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
-    { name = "click", specifier = ">=8.3.0" },
     { name = "django", specifier = ">=5.2.7" },
     { name = "djangorestframework", specifier = ">=3.16.1" },
     { name = "fastapi", specifier = ">=0.120.4" },
@@ -449,6 +460,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "asyncclick", specifier = ">=8.3.0.7" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "ipykernel", specifier = ">=7.1.0" },
     { name = "pandas", specifier = ">=2.3.3" },


### PR DESCRIPTION
This pull request migrates the CLI implementation from `click` to `asyncclick` to enable native async support for all CLI commands. This change allows asynchronous operations to be handled more efficiently, especially for commands that require async workflows such as web crawling and server management. The migration touches both the CLI entrypoints and the crawler command implementation, and updates dependencies accordingly.

**Migration to asyncclick for async CLI support:**

* Replaced all `click` imports with `asyncclick` in `backend/src/expenses_counter/utils/cli/main.py` and `backend/src/expenses_counter/utils/cli/crawler.py`, and updated all CLI command functions to be async. [[1]](diffhunk://#diff-6ec62eb9b94fe700586ed9bb2e9ccba85a5a74d3b3612bd5074a0777f26334ddL1-R1) [[2]](diffhunk://#diff-067a317cd6febff71535ee3726461b21eb7c4d5e2ff615bddc0ed49961f07194L5-L30)
* Refactored the `crawler` and `crawl_and_create` commands to be async, removing manual event loop management and leveraging async/await directly.
* Updated the main CLI group and all subcommands (`main`, `show_config`, `run`) to async functions, and modified the server startup logic to use `await server.serve()` instead of `uvicorn.run`. [[1]](diffhunk://#diff-6ec62eb9b94fe700586ed9bb2e9ccba85a5a74d3b3612bd5074a0777f26334ddL13-R13) [[2]](diffhunk://#diff-6ec62eb9b94fe700586ed9bb2e9ccba85a5a74d3b3612bd5074a0777f26334ddL33-R33) [[3]](diffhunk://#diff-6ec62eb9b94fe700586ed9bb2e9ccba85a5a74d3b3612bd5074a0777f26334ddL43-R43) [[4]](diffhunk://#diff-6ec62eb9b94fe700586ed9bb2e9ccba85a5a74d3b3612bd5074a0777f26334ddL60-R68)

**Dependency updates:**

* Removed `click` from the main dependencies and added `asyncclick` to the `dev` dependency group in `backend/pyproject.toml`. [[1]](diffhunk://#diff-9f2cf60079756e94b31dbaeb145297215236d3c0135647163c2e51b80fd81551L25) [[2]](diffhunk://#diff-9f2cf60079756e94b31dbaeb145297215236d3c0135647163c2e51b80fd81551R43)