### PR TITLE
Feat: Update migrations to support sqlite

### DIFF
--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_17-58_d25b6ed05167_create_base_tables.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_17-58_d25b6ed05167_create_base_tables.py
@@ -35,7 +35,7 @@ def upgrade():
         sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
         sa.Column("name", sa.String(length=150), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name="main_category_pkey"),
     )
 
     # Create main_price table
@@ -44,8 +44,8 @@ def upgrade():
         sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
         sa.Column("actual_price", sa.Numeric(precision=10, scale=2), nullable=False, server_default="0"),
         sa.Column("full_price", sa.Numeric(precision=10, scale=2), nullable=True, server_default="0"),
-        sa.Column("date", sa.Date(), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
+        sa.Column("date", sa.Date(), nullable=False, quote=True),
+        sa.PrimaryKeyConstraint("id", name="main_price_pkey"),
     )
 
     # Create main_shop table
@@ -55,7 +55,7 @@ def upgrade():
         sa.Column("address", sa.String(length=150), nullable=True),
         sa.Column("name", sa.String(length=150), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name="main_shop_pkey"),
     )
 
     # Create main_subcategory table (depends on main_category)
@@ -65,8 +65,10 @@ def upgrade():
         sa.Column("name", sa.String(length=150), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("category_id", sa.BigInteger(), nullable=False),
-        sa.ForeignKeyConstraint(["category_id"], ["main_category.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["category_id"], ["main_category.id"], ondelete="CASCADE", name="main_subcategory_category_id_fkey"
+        ),
+        sa.PrimaryKeyConstraint("id", name="main_subcategory_pkey"),
     )
 
     # Create main_product table (depends on main_price, main_shop, main_subcategory)
@@ -78,10 +80,12 @@ def upgrade():
         sa.Column("price_id", sa.BigInteger(), nullable=False),
         sa.Column("shop_id", sa.BigInteger(), nullable=False),
         sa.Column("sub_category_id", sa.BigInteger(), nullable=False),
-        sa.ForeignKeyConstraint(["price_id"], ["main_price.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["shop_id"], ["main_shop.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["sub_category_id"], ["main_subcategory.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["price_id"], ["main_price.id"], ondelete="CASCADE", name="main_product_price_id_fkey"),
+        sa.ForeignKeyConstraint(["shop_id"], ["main_shop.id"], ondelete="CASCADE", name="main_product_shop_id_fkey"),
+        sa.ForeignKeyConstraint(
+            ["sub_category_id"], ["main_subcategory.id"], ondelete="CASCADE", name="main_product_sub_category_id_fkey"
+        ),
+        sa.PrimaryKeyConstraint("id", name="main_product_pkey"),
     )
 
 

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_17-58_d25b6ed05167_create_base_tables.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_17-58_d25b6ed05167_create_base_tables.py
@@ -32,7 +32,7 @@ def upgrade():
     # Create main_category table
     op.create_table(
         "main_category",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), autoincrement=True, nullable=False),
         sa.Column("name", sa.String(length=150), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
         sa.PrimaryKeyConstraint("id", name="main_category_pkey"),
@@ -41,7 +41,7 @@ def upgrade():
     # Create main_price table
     op.create_table(
         "main_price",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), autoincrement=True, nullable=False),
         sa.Column("actual_price", sa.Numeric(precision=10, scale=2), nullable=False, server_default="0"),
         sa.Column("full_price", sa.Numeric(precision=10, scale=2), nullable=True, server_default="0"),
         sa.Column("date", sa.Date(), nullable=False, quote=True),
@@ -51,7 +51,7 @@ def upgrade():
     # Create main_shop table
     op.create_table(
         "main_shop",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), autoincrement=True, nullable=False),
         sa.Column("address", sa.String(length=150), nullable=True),
         sa.Column("name", sa.String(length=150), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
@@ -61,10 +61,10 @@ def upgrade():
     # Create main_subcategory table (depends on main_category)
     op.create_table(
         "main_subcategory",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), autoincrement=True, nullable=False),
         sa.Column("name", sa.String(length=150), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("category_id", sa.BigInteger(), nullable=False),
+        sa.Column("category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False),
         sa.ForeignKeyConstraint(
             ["category_id"], ["main_category.id"], ondelete="CASCADE", name="main_subcategory_category_id_fkey"
         ),
@@ -74,12 +74,12 @@ def upgrade():
     # Create main_product table (depends on main_price, main_shop, main_subcategory)
     op.create_table(
         "main_product",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), autoincrement=True, nullable=False),
         sa.Column("name", sa.String(length=150), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("price_id", sa.BigInteger(), nullable=False),
-        sa.Column("shop_id", sa.BigInteger(), nullable=False),
-        sa.Column("sub_category_id", sa.BigInteger(), nullable=False),
+        sa.Column("price_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False),
+        sa.Column("shop_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False),
+        sa.Column("sub_category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False),
         sa.ForeignKeyConstraint(["price_id"], ["main_price.id"], ondelete="CASCADE", name="main_product_price_id_fkey"),
         sa.ForeignKeyConstraint(["shop_id"], ["main_shop.id"], ondelete="CASCADE", name="main_product_shop_id_fkey"),
         sa.ForeignKeyConstraint(

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-05_c419e4062eff_create_transaction_and_shopaddress_.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-05_c419e4062eff_create_transaction_and_shopaddress_.py
@@ -51,12 +51,12 @@ def upgrade():
     # Create main_transaction table
     op.create_table(
         "main_transaction",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), autoincrement=True, nullable=False),
         sa.Column("date", sa.Date(), nullable=False, quote=True),
-        sa.Column("price_id", sa.BigInteger(), nullable=False),
-        sa.Column("product_id", sa.BigInteger(), nullable=False),
-        sa.Column("shop_id", sa.BigInteger(), nullable=False),
-        sa.Column("sub_category_id", sa.BigInteger(), nullable=False),
+        sa.Column("price_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False),
+        sa.Column("product_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False),
+        sa.Column("shop_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False),
+        sa.Column("sub_category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False),
         sa.ForeignKeyConstraint(
             ["price_id"], ["main_price.id"], ondelete="CASCADE", name="main_transaction_price_id_fkey"
         ),
@@ -78,9 +78,9 @@ def upgrade():
     # Create main_shopaddress table
     op.create_table(
         "main_shopaddress",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), autoincrement=True, nullable=False),
         sa.Column("address", sa.String(length=150), nullable=False),
-        sa.Column("shop_id", sa.BigInteger(), nullable=False),
+        sa.Column("shop_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False),
         sa.ForeignKeyConstraint(
             ["shop_id"], ["main_shop.id"], ondelete="CASCADE", name="main_shopaddress_shop_id_fkey"
         ),
@@ -110,17 +110,19 @@ def downgrade():
 
     # Re-add foreign key columns to main_product
     with op.batch_alter_table("main_product") as batch_op:
-        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=False))
+        batch_op.add_column(
+            sa.Column("sub_category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False)
+        )
         batch_op.create_foreign_key(
             "main_product_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
         )
 
     with op.batch_alter_table("main_product") as batch_op:
-        batch_op.add_column(sa.Column("shop_id", sa.BigInteger(), nullable=False))
+        batch_op.add_column(sa.Column("shop_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False))
         batch_op.create_foreign_key("main_product_shop_id_fkey", "main_shop", ["shop_id"], ["id"], ondelete="CASCADE")
 
     with op.batch_alter_table("main_product") as batch_op:
-        batch_op.add_column(sa.Column("price_id", sa.BigInteger(), nullable=False))
+        batch_op.add_column(sa.Column("price_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False))
         batch_op.create_foreign_key(
             "main_product_price_id_fkey", "main_price", ["price_id"], ["id"], ondelete="CASCADE"
         )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-05_c419e4062eff_create_transaction_and_shopaddress_.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-05_c419e4062eff_create_transaction_and_shopaddress_.py
@@ -30,35 +30,49 @@ def upgrade():
     transaction table, allowing products to exist independently of specific purchases.
     """
     # Remove field date from main_price
-    op.drop_column("main_price", "date")
+    with op.batch_alter_table("main_price") as batch_op:
+        batch_op.drop_column("date")
 
     # Remove foreign key constraints and columns from main_product
-    op.drop_constraint("main_product_price_id_fkey", "main_product", type_="foreignkey")
-    op.drop_column("main_product", "price_id")
+    with op.batch_alter_table("main_product") as batch_op:
+        batch_op.drop_constraint("main_product_price_id_fkey", type_="foreignkey")
+        batch_op.drop_column("price_id")
 
-    op.drop_constraint("main_product_shop_id_fkey", "main_product", type_="foreignkey")
-    op.drop_column("main_product", "shop_id")
+        batch_op.drop_constraint("main_product_shop_id_fkey", type_="foreignkey")
+        batch_op.drop_column("shop_id")
 
-    op.drop_constraint("main_product_sub_category_id_fkey", "main_product", type_="foreignkey")
-    op.drop_column("main_product", "sub_category_id")
+        batch_op.drop_constraint("main_product_sub_category_id_fkey", type_="foreignkey")
+        batch_op.drop_column("sub_category_id")
 
     # Remove field address from main_shop
-    op.drop_column("main_shop", "address")
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.drop_column("address")
 
     # Create main_transaction table
     op.create_table(
         "main_transaction",
         sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
-        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False, quote=True),
         sa.Column("price_id", sa.BigInteger(), nullable=False),
         sa.Column("product_id", sa.BigInteger(), nullable=False),
         sa.Column("shop_id", sa.BigInteger(), nullable=False),
         sa.Column("sub_category_id", sa.BigInteger(), nullable=False),
-        sa.ForeignKeyConstraint(["price_id"], ["main_price.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["product_id"], ["main_product.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["shop_id"], ["main_shop.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["sub_category_id"], ["main_subcategory.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["price_id"], ["main_price.id"], ondelete="CASCADE", name="main_transaction_price_id_fkey"
+        ),
+        sa.ForeignKeyConstraint(
+            ["product_id"], ["main_product.id"], ondelete="CASCADE", name="main_transaction_product_id_fkey"
+        ),
+        sa.ForeignKeyConstraint(
+            ["shop_id"], ["main_shop.id"], ondelete="CASCADE", name="main_transaction_shop_id_fkey"
+        ),
+        sa.ForeignKeyConstraint(
+            ["sub_category_id"],
+            ["main_subcategory.id"],
+            ondelete="CASCADE",
+            name="main_transaction_sub_category_id_fkey",
+        ),
+        sa.PrimaryKeyConstraint("id", name="main_transaction_pkey"),
     )
 
     # Create main_shopaddress table
@@ -67,8 +81,10 @@ def upgrade():
         sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
         sa.Column("address", sa.String(length=150), nullable=False),
         sa.Column("shop_id", sa.BigInteger(), nullable=False),
-        sa.ForeignKeyConstraint(["shop_id"], ["main_shop.id"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["shop_id"], ["main_shop.id"], ondelete="CASCADE", name="main_shopaddress_shop_id_fkey"
+        ),
+        sa.PrimaryKeyConstraint("id", name="main_shopaddress_pkey"),
     )
 
 
@@ -89,28 +105,26 @@ def downgrade():
     op.drop_table("main_transaction")
 
     # Re-add address column to main_shop
-    op.add_column("main_shop", sa.Column("address", sa.String(length=150), nullable=True))
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.add_column(sa.Column("address", sa.String(length=150), nullable=True))
 
     # Re-add foreign key columns to main_product
-    op.add_column("main_product", sa.Column("sub_category_id", sa.BigInteger(), nullable=False))
-    op.create_foreign_key(
-        "main_product_sub_category_id_fkey",
-        "main_product",
-        "main_subcategory",
-        ["sub_category_id"],
-        ["id"],
-        ondelete="CASCADE",
-    )
+    with op.batch_alter_table("main_product") as batch_op:
+        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=False))
+        batch_op.create_foreign_key(
+            "main_product_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
+        )
 
-    op.add_column("main_product", sa.Column("shop_id", sa.BigInteger(), nullable=False))
-    op.create_foreign_key(
-        "main_product_shop_id_fkey", "main_product", "main_shop", ["shop_id"], ["id"], ondelete="CASCADE"
-    )
+    with op.batch_alter_table("main_product") as batch_op:
+        batch_op.add_column(sa.Column("shop_id", sa.BigInteger(), nullable=False))
+        batch_op.create_foreign_key("main_product_shop_id_fkey", "main_shop", ["shop_id"], ["id"], ondelete="CASCADE")
 
-    op.add_column("main_product", sa.Column("price_id", sa.BigInteger(), nullable=False))
-    op.create_foreign_key(
-        "main_product_price_id_fkey", "main_product", "main_price", ["price_id"], ["id"], ondelete="CASCADE"
-    )
+    with op.batch_alter_table("main_product") as batch_op:
+        batch_op.add_column(sa.Column("price_id", sa.BigInteger(), nullable=False))
+        batch_op.create_foreign_key(
+            "main_product_price_id_fkey", "main_price", ["price_id"], ["id"], ondelete="CASCADE"
+        )
 
     # Re-add date column to main_price
-    op.add_column("main_price", sa.Column("date", sa.Date(), nullable=False))
+    with op.batch_alter_table("main_price") as batch_op:
+        batch_op.add_column(sa.Column("date", sa.Date(), nullable=False, quote=True))

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-05_c419e4062eff_create_transaction_and_shopaddress_.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-05_c419e4062eff_create_transaction_and_shopaddress_.py
@@ -116,12 +116,8 @@ def downgrade():
         batch_op.create_foreign_key(
             "main_product_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
         )
-
-    with op.batch_alter_table("main_product") as batch_op:
         batch_op.add_column(sa.Column("shop_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False))
         batch_op.create_foreign_key("main_product_shop_id_fkey", "main_shop", ["shop_id"], ["id"], ondelete="CASCADE")
-
-    with op.batch_alter_table("main_product") as batch_op:
         batch_op.add_column(sa.Column("price_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False))
         batch_op.create_foreign_key(
             "main_product_price_id_fkey", "main_price", ["price_id"], ["id"], ondelete="CASCADE"

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-08_95009cbed51f_change_price_type.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-08_95009cbed51f_change_price_type.py
@@ -31,13 +31,7 @@ def upgrade():
     # Drop the foreign key constraint first
     with op.batch_alter_table("main_transaction") as batch_op:
         batch_op.drop_constraint("main_transaction_price_id_fkey", type_="foreignkey")
-
-    # Drop the old price_id column
-    with op.batch_alter_table("main_transaction") as batch_op:
         batch_op.drop_column("price_id")
-
-    # Add the new price column as a decimal field
-    with op.batch_alter_table("main_transaction") as batch_op:
         batch_op.add_column(
             sa.Column("price", sa.Numeric(precision=10, scale=2), nullable=False, server_default="0"),
         )
@@ -57,13 +51,7 @@ def downgrade():
     # Drop the decimal price column
     with op.batch_alter_table("main_transaction") as batch_op:
         batch_op.drop_column("price")
-
-    # Re-add the price_id foreign key column
-    with op.batch_alter_table("main_transaction") as batch_op:
         batch_op.add_column(sa.Column("price_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False))
-
-    # Re-create the foreign key constraint
-    with op.batch_alter_table("main_transaction") as batch_op:
         batch_op.create_foreign_key(
             "main_transaction_price_id_fkey", "main_price", ["price_id"], ["id"], ondelete="CASCADE"
         )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-08_95009cbed51f_change_price_type.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-08_95009cbed51f_change_price_type.py
@@ -29,15 +29,18 @@ def upgrade():
     for transaction records.
     """
     # Drop the foreign key constraint first
-    op.drop_constraint("main_transaction_price_id_fkey", "main_transaction", type_="foreignkey")
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.drop_constraint("main_transaction_price_id_fkey", type_="foreignkey")
 
     # Drop the old price_id column
-    op.drop_column("main_transaction", "price_id")
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.drop_column("price_id")
 
     # Add the new price column as a decimal field
-    op.add_column(
-        "main_transaction", sa.Column("price", sa.Numeric(precision=10, scale=2), nullable=False, server_default="0")
-    )
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.add_column(
+            sa.Column("price", sa.Numeric(precision=10, scale=2), nullable=False, server_default="0"),
+        )
 
 
 def downgrade():
@@ -52,12 +55,15 @@ def downgrade():
     automatically converted back to price_id references.
     """
     # Drop the decimal price column
-    op.drop_column("main_transaction", "price")
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.drop_column("price")
 
     # Re-add the price_id foreign key column
-    op.add_column("main_transaction", sa.Column("price_id", sa.BigInteger(), nullable=False))
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.add_column(sa.Column("price_id", sa.BigInteger(), nullable=False))
 
     # Re-create the foreign key constraint
-    op.create_foreign_key(
-        "main_transaction_price_id_fkey", "main_transaction", "main_price", ["price_id"], ["id"], ondelete="CASCADE"
-    )
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.create_foreign_key(
+            "main_transaction_price_id_fkey", "main_price", ["price_id"], ["id"], ondelete="CASCADE"
+        )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-08_95009cbed51f_change_price_type.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-08_95009cbed51f_change_price_type.py
@@ -60,7 +60,7 @@ def downgrade():
 
     # Re-add the price_id foreign key column
     with op.batch_alter_table("main_transaction") as batch_op:
-        batch_op.add_column(sa.Column("price_id", sa.BigInteger(), nullable=False))
+        batch_op.add_column(sa.Column("price_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False))
 
     # Re-create the foreign key constraint
     with op.batch_alter_table("main_transaction") as batch_op:

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-11_3e0192741b18_drop_price_table.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-11_3e0192741b18_drop_price_table.py
@@ -42,5 +42,5 @@ def downgrade():
         sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
         sa.Column("actual_price", sa.Numeric(precision=10, scale=2), nullable=False, server_default="0"),
         sa.Column("full_price", sa.Numeric(precision=10, scale=2), nullable=True, server_default="0"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("id", name="main_price_pkey"),
     )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-11_3e0192741b18_drop_price_table.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-11_3e0192741b18_drop_price_table.py
@@ -39,7 +39,7 @@ def downgrade():
     """
     op.create_table(
         "main_price",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), autoincrement=True, nullable=False),
         sa.Column("actual_price", sa.Numeric(precision=10, scale=2), nullable=False, server_default="0"),
         sa.Column("full_price", sa.Numeric(precision=10, scale=2), nullable=True, server_default="0"),
         sa.PrimaryKeyConstraint("id", name="main_price_pkey"),

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-13_2b5618753d8b_add_sub_category_field_to_product_table.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-13_2b5618753d8b_add_sub_category_field_to_product_table.py
@@ -24,7 +24,9 @@ def upgrade():
     to allow for products without assigned subcategories.
     """
     with op.batch_alter_table("main_product") as batch_op:
-        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.add_column(
+            sa.Column("sub_category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=True)
+        )
         batch_op.create_foreign_key(
             "main_product_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
         )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-13_2b5618753d8b_add_sub_category_field_to_product_table.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-13_2b5618753d8b_add_sub_category_field_to_product_table.py
@@ -23,15 +23,11 @@ def upgrade():
     allowing products to be associated with subcategories. The field is nullable
     to allow for products without assigned subcategories.
     """
-    op.add_column("main_product", sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
-    op.create_foreign_key(
-        "main_product_sub_category_id_fkey",
-        "main_product",
-        "main_subcategory",
-        ["sub_category_id"],
-        ["id"],
-        ondelete="CASCADE",
-    )
+    with op.batch_alter_table("main_product") as batch_op:
+        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.create_foreign_key(
+            "main_product_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
+        )
 
 
 def downgrade():
@@ -40,5 +36,6 @@ def downgrade():
     Drops the foreign key constraint and removes the sub_category_id column
     from the main_product table.
     """
-    op.drop_constraint("main_product_sub_category_id_fkey", "main_product", type_="foreignkey")
-    op.drop_column("main_product", "sub_category_id")
+    with op.batch_alter_table("main_product") as batch_op:
+        batch_op.drop_constraint("main_product_sub_category_id_fkey", type_="foreignkey")
+        batch_op.drop_column("sub_category_id")

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-14_a7b30ff4aaf5_remove_sub_category_field_from_.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-14_a7b30ff4aaf5_remove_sub_category_field_from_.py
@@ -23,7 +23,8 @@ def upgrade():
     This is likely because subcategory information can be derived from
     the product relationship instead of being stored redundantly.
     """
-    op.drop_column("main_transaction", "sub_category_id")
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.drop_column("sub_category_id")
 
 
 def downgrade():
@@ -32,12 +33,8 @@ def downgrade():
     Re-adds the nullable sub_category_id foreign key column to main_transaction
     and recreates the foreign key constraint to main_subcategory table.
     """
-    op.add_column("main_transaction", sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
-    op.create_foreign_key(
-        "main_transaction_sub_category_id_fkey",
-        "main_transaction",
-        "main_subcategory",
-        ["sub_category_id"],
-        ["id"],
-        ondelete="CASCADE",
-    )
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.create_foreign_key(
+            "main_transaction_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
+        )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-14_a7b30ff4aaf5_remove_sub_category_field_from_.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-14_a7b30ff4aaf5_remove_sub_category_field_from_.py
@@ -34,7 +34,9 @@ def downgrade():
     and recreates the foreign key constraint to main_subcategory table.
     """
     with op.batch_alter_table("main_transaction") as batch_op:
-        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.add_column(
+            sa.Column("sub_category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=True)
+        )
         batch_op.create_foreign_key(
             "main_transaction_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
         )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-15_23f7346bac63_add_local_name_field_to_shopaddress_.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-15_23f7346bac63_add_local_name_field_to_shopaddress_.py
@@ -23,7 +23,8 @@ def upgrade():
     main_shopaddress table. This field likely stores a localized or custom
     name for the specific shop location/address.
     """
-    op.add_column("main_shopaddress", sa.Column("local_name", sa.String(length=150), nullable=False))
+    with op.batch_alter_table("main_shopaddress") as batch_op:
+        batch_op.add_column(sa.Column("local_name", sa.String(length=150), nullable=False))
 
 
 def downgrade():
@@ -31,4 +32,5 @@ def downgrade():
 
     Drops the local_name column from main_shopaddress table.
     """
-    op.drop_column("main_shopaddress", "local_name")
+    with op.batch_alter_table("main_shopaddress") as batch_op:
+        batch_op.drop_column("local_name")

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-15_5f5d77d90c89_add_icon_field_to_shop_table.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-15_5f5d77d90c89_add_icon_field_to_shop_table.py
@@ -22,7 +22,8 @@ def upgrade():
     Adds a nullable icon column (String, max 150 characters) to main_shop table.
     This field likely stores a file path or identifier for the shop's icon/logo.
     """
-    op.add_column("main_shop", sa.Column("icon", sa.String(length=150), nullable=True))
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.add_column(sa.Column("icon", sa.String(length=150), nullable=True))
 
 
 def downgrade():
@@ -30,4 +31,5 @@ def downgrade():
 
     Drops the icon column from main_shop table.
     """
-    op.drop_column("main_shop", "icon")
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.drop_column("icon")

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-17_017ee3dc6009_add_count_field_to_transaction_table.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-17_017ee3dc6009_add_count_field_to_transaction_table.py
@@ -24,9 +24,8 @@ def upgrade():
     the quantity of items purchased in each transaction, supporting decimal
     quantities (e.g., 1.5 kg of produce).
     """
-    op.add_column(
-        "main_transaction", sa.Column("count", sa.Numeric(precision=10, scale=3), nullable=False, server_default="0")
-    )
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.add_column(sa.Column("count", sa.Numeric(precision=10, scale=3), nullable=False, server_default="0"))
 
 
 def downgrade():
@@ -34,4 +33,5 @@ def downgrade():
 
     Drops the count column from main_transaction table.
     """
-    op.drop_column("main_transaction", "count")
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.drop_column("count")

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-17_b49a0bf2e1e8_add_sub_category_field_to_shop_table.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-17_b49a0bf2e1e8_add_sub_category_field_to_shop_table.py
@@ -24,7 +24,9 @@ def upgrade():
     categorization of shops (e.g., grocery store, electronics, etc.).
     """
     with op.batch_alter_table("main_shop") as batch_op:
-        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.add_column(
+            sa.Column("sub_category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=True)
+        )
         batch_op.create_foreign_key(
             "main_shop_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
         )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-17_b49a0bf2e1e8_add_sub_category_field_to_shop_table.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-17_b49a0bf2e1e8_add_sub_category_field_to_shop_table.py
@@ -23,15 +23,11 @@ def upgrade():
     allowing shops to be associated with subcategories. This enables
     categorization of shops (e.g., grocery store, electronics, etc.).
     """
-    op.add_column("main_shop", sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
-    op.create_foreign_key(
-        "main_shop_sub_category_id_fkey",
-        "main_shop",
-        "main_subcategory",
-        ["sub_category_id"],
-        ["id"],
-        ondelete="CASCADE",
-    )
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.create_foreign_key(
+            "main_shop_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
+        )
 
 
 def downgrade():
@@ -40,5 +36,6 @@ def downgrade():
     Drops the foreign key constraint and removes the sub_category_id column
     from the main_shop table.
     """
-    op.drop_constraint("main_shop_sub_category_id_fkey", "main_shop", type_="foreignkey")
-    op.drop_column("main_shop", "sub_category_id")
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.drop_constraint("main_shop_sub_category_id_fkey", type_="foreignkey")
+        batch_op.drop_column("sub_category_id")

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-18_2e886bcabf9b_replace_shop_field_with_address_for_.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-18_2e886bcabf9b_replace_shop_field_with_address_for_.py
@@ -27,17 +27,13 @@ def upgrade():
     This allows transactions to be associated with specific shop locations
     rather than just the shop brand/chain.
     """
-    op.drop_constraint("main_transaction_shop_id_fkey", "main_transaction", type_="foreignkey")
-    op.drop_column("main_transaction", "shop_id")
-    op.add_column("main_transaction", sa.Column("address_id", sa.BigInteger(), nullable=False))
-    op.create_foreign_key(
-        "main_transaction_address_id_fkey",
-        "main_transaction",
-        "main_shopaddress",
-        ["address_id"],
-        ["id"],
-        ondelete="CASCADE",
-    )
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.drop_constraint("main_transaction_shop_id_fkey", type_="foreignkey")
+        batch_op.drop_column("shop_id")
+        batch_op.add_column(sa.Column("address_id", sa.BigInteger(), nullable=False))
+        batch_op.create_foreign_key(
+            "main_transaction_address_id_fkey", "main_shopaddress", ["address_id"], ["id"], ondelete="CASCADE"
+        )
 
 
 def downgrade():
@@ -50,9 +46,10 @@ def downgrade():
     Note: This will result in data loss as address-specific information
     cannot be automatically converted back to shop references.
     """
-    op.drop_constraint("main_transaction_address_id_fkey", "main_transaction", type_="foreignkey")
-    op.drop_column("main_transaction", "address_id")
-    op.add_column("main_transaction", sa.Column("shop_id", sa.BigInteger(), nullable=False))
-    op.create_foreign_key(
-        "main_transaction_shop_id_fkey", "main_transaction", "main_shop", ["shop_id"], ["id"], ondelete="CASCADE"
-    )
+    with op.batch_alter_table("main_transaction") as batch_op:
+        batch_op.drop_constraint("main_transaction_address_id_fkey", type_="foreignkey")
+        batch_op.drop_column("address_id")
+        batch_op.add_column(sa.Column("shop_id", sa.BigInteger(), nullable=False))
+        batch_op.create_foreign_key(
+            "main_transaction_shop_id_fkey", "main_shop", ["shop_id"], ["id"], ondelete="CASCADE"
+        )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-18_2e886bcabf9b_replace_shop_field_with_address_for_.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-18_2e886bcabf9b_replace_shop_field_with_address_for_.py
@@ -30,7 +30,9 @@ def upgrade():
     with op.batch_alter_table("main_transaction") as batch_op:
         batch_op.drop_constraint("main_transaction_shop_id_fkey", type_="foreignkey")
         batch_op.drop_column("shop_id")
-        batch_op.add_column(sa.Column("address_id", sa.BigInteger(), nullable=False))
+        batch_op.add_column(
+            sa.Column("address_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False)
+        )
         batch_op.create_foreign_key(
             "main_transaction_address_id_fkey", "main_shopaddress", ["address_id"], ["id"], ondelete="CASCADE"
         )
@@ -49,7 +51,7 @@ def downgrade():
     with op.batch_alter_table("main_transaction") as batch_op:
         batch_op.drop_constraint("main_transaction_address_id_fkey", type_="foreignkey")
         batch_op.drop_column("address_id")
-        batch_op.add_column(sa.Column("shop_id", sa.BigInteger(), nullable=False))
+        batch_op.add_column(sa.Column("shop_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=False))
         batch_op.create_foreign_key(
             "main_transaction_shop_id_fkey", "main_shop", ["shop_id"], ["id"], ondelete="CASCADE"
         )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-19_0a4f7ff49f65_set_shop_icon_nullable.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-19_0a4f7ff49f65_set_shop_icon_nullable.py
@@ -23,7 +23,8 @@ def upgrade():
     Note: The icon field was already nullable in a previous migration, so this
     may be ensuring the constraint is properly set.
     """
-    op.alter_column("main_shop", "icon", nullable=True)
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.alter_column("icon", nullable=True)
 
 
 def downgrade():
@@ -32,4 +33,5 @@ def downgrade():
     Changes the icon column in main_shop table to require a value (NOT NULL).
     Note: This downgrade may fail if there are existing shops with NULL icons.
     """
-    op.alter_column("main_shop", "icon", nullable=False)
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.alter_column("icon", nullable=False)

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-21_7bc23a0f1288_switch_sub_category_field_with_category.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-21_7bc23a0f1288_switch_sub_category_field_with_category.py
@@ -33,19 +33,21 @@ def upgrade():
     This simplifies the data model by using categories directly instead of
     requiring subcategories.
     """
-    op.drop_constraint("main_shop_sub_category_id_fkey", "main_shop", type_="foreignkey")
-    op.drop_column("main_shop", "sub_category_id")
-    op.add_column("main_shop", sa.Column("category_id", sa.BigInteger(), nullable=True))
-    op.create_foreign_key(
-        "main_shop_category_id_fkey", "main_shop", "main_category", ["category_id"], ["id"], ondelete="CASCADE"
-    )
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.drop_constraint("main_shop_sub_category_id_fkey", type_="foreignkey")
+        batch_op.drop_column("sub_category_id")
+        batch_op.add_column(sa.Column("category_id", sa.BigInteger(), nullable=True))
+        batch_op.create_foreign_key(
+            "main_shop_category_id_fkey", "main_category", ["category_id"], ["id"], ondelete="CASCADE"
+        )
 
-    op.drop_constraint("main_product_sub_category_id_fkey", "main_product", type_="foreignkey")
-    op.drop_column("main_product", "sub_category_id")
-    op.add_column("main_product", sa.Column("category_id", sa.BigInteger(), nullable=True))
-    op.create_foreign_key(
-        "main_product_category_id_fkey", "main_product", "main_category", ["category_id"], ["id"], ondelete="CASCADE"
-    )
+    with op.batch_alter_table("main_product") as batch_op:
+        batch_op.drop_constraint("main_product_sub_category_id_fkey", type_="foreignkey")
+        batch_op.drop_column("sub_category_id")
+        batch_op.add_column(sa.Column("category_id", sa.BigInteger(), nullable=True))
+        batch_op.create_foreign_key(
+            "main_product_category_id_fkey", "main_category", ["category_id"], ["id"], ondelete="CASCADE"
+        )
 
 
 def downgrade():
@@ -64,26 +66,18 @@ def downgrade():
     Note: This will result in data loss as category references cannot be
     automatically converted back to subcategory references.
     """
-    op.drop_constraint("main_shop_category_id_fkey", "main_shop", type_="foreignkey")
-    op.drop_column("main_shop", "category_id")
-    op.add_column("main_shop", sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
-    op.create_foreign_key(
-        "main_shop_sub_category_id_fkey",
-        "main_shop",
-        "main_subcategory",
-        ["sub_category_id"],
-        ["id"],
-        ondelete="CASCADE",
-    )
+    with op.batch_alter_table("main_shop") as batch_op:
+        batch_op.drop_constraint("main_shop_category_id_fkey", type_="foreignkey")
+        batch_op.drop_column("category_id")
+        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.create_foreign_key(
+            "main_shop_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
+        )
 
-    op.drop_constraint("main_product_category_id_fkey", "main_product", type_="foreignkey")
-    op.drop_column("main_product", "category_id")
-    op.add_column("main_product", sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
-    op.create_foreign_key(
-        "main_product_sub_category_id_fkey",
-        "main_product",
-        "main_subcategory",
-        ["sub_category_id"],
-        ["id"],
-        ondelete="CASCADE",
-    )
+    with op.batch_alter_table("main_product") as batch_op:
+        batch_op.drop_constraint("main_product_category_id_fkey", type_="foreignkey")
+        batch_op.drop_column("category_id")
+        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.create_foreign_key(
+            "main_product_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
+        )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-21_7bc23a0f1288_switch_sub_category_field_with_category.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-21_7bc23a0f1288_switch_sub_category_field_with_category.py
@@ -36,7 +36,9 @@ def upgrade():
     with op.batch_alter_table("main_shop") as batch_op:
         batch_op.drop_constraint("main_shop_sub_category_id_fkey", type_="foreignkey")
         batch_op.drop_column("sub_category_id")
-        batch_op.add_column(sa.Column("category_id", sa.BigInteger(), nullable=True))
+        batch_op.add_column(
+            sa.Column("category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=True)
+        )
         batch_op.create_foreign_key(
             "main_shop_category_id_fkey", "main_category", ["category_id"], ["id"], ondelete="CASCADE"
         )
@@ -44,7 +46,9 @@ def upgrade():
     with op.batch_alter_table("main_product") as batch_op:
         batch_op.drop_constraint("main_product_sub_category_id_fkey", type_="foreignkey")
         batch_op.drop_column("sub_category_id")
-        batch_op.add_column(sa.Column("category_id", sa.BigInteger(), nullable=True))
+        batch_op.add_column(
+            sa.Column("category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=True)
+        )
         batch_op.create_foreign_key(
             "main_product_category_id_fkey", "main_category", ["category_id"], ["id"], ondelete="CASCADE"
         )
@@ -69,7 +73,9 @@ def downgrade():
     with op.batch_alter_table("main_shop") as batch_op:
         batch_op.drop_constraint("main_shop_category_id_fkey", type_="foreignkey")
         batch_op.drop_column("category_id")
-        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.add_column(
+            sa.Column("sub_category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=True)
+        )
         batch_op.create_foreign_key(
             "main_shop_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
         )
@@ -77,7 +83,9 @@ def downgrade():
     with op.batch_alter_table("main_product") as batch_op:
         batch_op.drop_constraint("main_product_category_id_fkey", type_="foreignkey")
         batch_op.drop_column("category_id")
-        batch_op.add_column(sa.Column("sub_category_id", sa.BigInteger(), nullable=True))
+        batch_op.add_column(
+            sa.Column("sub_category_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=True)
+        )
         batch_op.create_foreign_key(
             "main_product_sub_category_id_fkey", "main_subcategory", ["sub_category_id"], ["id"], ondelete="CASCADE"
         )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-25_f68d0ab7444f_add_self_to_category_table_parent.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-25_f68d0ab7444f_add_self_to_category_table_parent.py
@@ -30,7 +30,7 @@ def upgrade():
     - Category trees of arbitrary depth
     """
     with op.batch_alter_table("main_category") as batch_op:
-        batch_op.add_column(sa.Column("parent_id", sa.BigInteger(), nullable=True))
+        batch_op.add_column(sa.Column("parent_id", sa.BigInteger().with_variant(sa.Integer(), "sqlite"), nullable=True))
         batch_op.create_foreign_key(
             "main_category_parent_id_fkey", "main_category", ["parent_id"], ["id"], ondelete="CASCADE"
         )

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-25_f68d0ab7444f_add_self_to_category_table_parent.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2025-12-22_18-25_f68d0ab7444f_add_self_to_category_table_parent.py
@@ -29,10 +29,11 @@ def upgrade():
     - Parent-child category relationships
     - Category trees of arbitrary depth
     """
-    op.add_column("main_category", sa.Column("parent_id", sa.BigInteger(), nullable=True))
-    op.create_foreign_key(
-        "main_category_parent_id_fkey", "main_category", "main_category", ["parent_id"], ["id"], ondelete="CASCADE"
-    )
+    with op.batch_alter_table("main_category") as batch_op:
+        batch_op.add_column(sa.Column("parent_id", sa.BigInteger(), nullable=True))
+        batch_op.create_foreign_key(
+            "main_category_parent_id_fkey", "main_category", ["parent_id"], ["id"], ondelete="CASCADE"
+        )
 
 
 def downgrade():
@@ -42,5 +43,6 @@ def downgrade():
     main_category table, eliminating the hierarchical structure and flattening
     all categories to a single level.
     """
-    op.drop_constraint("main_category_parent_id_fkey", "main_category", type_="foreignkey")
-    op.drop_column("main_category", "parent_id")
+    with op.batch_alter_table("main_category") as batch_op:
+        batch_op.drop_constraint("main_category_parent_id_fkey", type_="foreignkey")
+        batch_op.drop_column("parent_id")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,12 +10,12 @@ from typing import AsyncGenerator
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import text
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
 
 from expenses_counter.config import AppConfig
 from expenses_counter.config.base.storage import SettingsStorage
 from expenses_counter.services.database import AsyncDatabaseClient
-from expenses_counter.services.database.models.base import mapper_registry
 from expenses_counter.utils import Singleton
 
 
@@ -107,54 +107,44 @@ def test_config(test_db_path: Path) -> AppConfig:
 
 @pytest_asyncio.fixture(scope="session")
 async def test_database_with_migrations(
-    test_config: AppConfig,
+    test_config: AppConfig,  # noqa: ARG001
     test_db_path: Path,
 ) -> AsyncGenerator[Path, None]:
-    """Create test database and apply schema.
+    """Create test database and apply schema via Alembic migrations.
 
     This fixture:
     1. Creates a fresh test database using SQLite
-    2. Creates all tables from SQLAlchemy models
+    2. Runs Alembic ``upgrade head`` to apply all migrations
     3. Yields the database path for tests to use
     4. Cleans up after all tests complete
 
-    Note: This fixture creates tables directly from SQLAlchemy metadata
-    rather than running Alembic migrations. This is simpler and more
-    reliable for testing, as it avoids event loop conflicts.
+    Alembic is run in a worker thread so its internal ``asyncio.run()`` call
+    does not conflict with the already-running pytest-asyncio event loop.
+    The migration env.py picks up the test database URL automatically via
+    ``AppConfig.get_or_create()``, which reads from the singleton
+    ``SettingsStorage`` populated by the ``test_config`` fixture.
 
     Args:
-        test_config: Test configuration with database settings.
+        test_config: Test configuration with database settings (stored in
+            SettingsStorage so Alembic env.py can find it).
         test_db_path: Path to the test database file.
 
     Yields:
-        Path: Path to the test database with schema applied.
+        Path: Path to the test database with all migrations applied.
 
     """
-    from sqlalchemy.ext.asyncio import create_async_engine
+    _alembic_ini = Path(__file__).parent.parent / "src" / "expenses_counter" / "services" / "alembic" / "alembic.ini"
 
-    # Create engine
-    engine = create_async_engine(
-        test_config.services.database.url,
-        echo=test_config.info.api_info.debug,
-        future=True,
-    )
+    def _run_migrations() -> None:
+        cfg = AlembicConfig(str(_alembic_ini))
+        alembic_command.upgrade(cfg, "head")
 
     try:
-        # Create all tables from metadata
-        async with engine.begin() as conn:
-            await conn.run_sync(mapper_registry.metadata.create_all)
-
-        # Verify database is accessible
-        async with engine.connect() as conn:
-            await conn.execute(text("SELECT 1"))
+        await asyncio.to_thread(_run_migrations)
 
         yield test_db_path
 
     finally:
-        # Cleanup: dispose engine and drop database
-        await engine.dispose()
-
-        # Drop test database by removing the file
         if test_db_path.exists():
             test_db_path.unlink()
 


### PR DESCRIPTION
This pull request refactors multiple Alembic database migration scripts to use SQLAlchemy's `batch_alter_table` context manager for all schema changes (adding, dropping columns and constraints). This approach improves migration compatibility, especially with SQLite, and ensures consistent handling of column types and constraints across different database backends. Additionally, it standardizes the use of named primary keys and foreign keys, and ensures type variants for SQLite are specified where needed.

The most important changes are:

**Migration compatibility and safety improvements:**

* Replaced direct `op.add_column`, `op.drop_column`, `op.create_foreign_key`, and `op.drop_constraint` calls with `op.batch_alter_table` context managers in all upgrade and downgrade functions, ensuring safe schema changes and better SQLite support. [[1]](diffhunk://#diff-538bc6c03c8e140654bd62b0e3294f834dbd20479fd27c2160b579f8a4d796e8L33-R87) [[2]](diffhunk://#diff-538bc6c03c8e140654bd62b0e3294f834dbd20479fd27c2160b579f8a4d796e8L92-R132) [[3]](diffhunk://#diff-79579e77b41e7908d2e90ce9f4f5f816cf2a460621cf8e5a0dd91d19ecb1cdbbL32-R42) [[4]](diffhunk://#diff-79579e77b41e7908d2e90ce9f4f5f816cf2a460621cf8e5a0dd91d19ecb1cdbbL55-R68) [[5]](diffhunk://#diff-a299af1145650c4718d50cfe239270a07f0858dfdb244d9cd1ecc4ac20e69995L26-R31) [[6]](diffhunk://#diff-a299af1145650c4718d50cfe239270a07f0858dfdb244d9cd1ecc4ac20e69995L43-R43) [[7]](diffhunk://#diff-d66e3bd6ca45714e65836d7f3993cbe8403209c836a933c03a531478763c1a7aL26-R27) [[8]](diffhunk://#diff-d66e3bd6ca45714e65836d7f3993cbe8403209c836a933c03a531478763c1a7aL35-R41) [[9]](diffhunk://#diff-e757e1e41ab1d4f887367fa91b1032c9603e327a89b6e570db36ff52fd7d91d6L26-R36) [[10]](diffhunk://#diff-4c945008ed9be10558d524479c8ffc966161afa3b39e9d3878e490d614f855d5L25-R35) [[11]](diffhunk://#diff-4502ceffb0c50e5cdcdb604744db913d432f9f31bbbe2b5c65a0b09f654bbd02L27-R37) [[12]](diffhunk://#diff-67f51aa5ddbd56567b7a0c5d2b8e8fd4af45707bac04e9aaa664349ec36b625cL26-R31) [[13]](diffhunk://#diff-67f51aa5ddbd56567b7a0c5d2b8e8fd4af45707bac04e9aaa664349ec36b625cL43-R43)

**Cross-database compatibility and constraint naming:**

* Updated all `id` and foreign key columns to use `sa.BigInteger().with_variant(sa.Integer(), "sqlite")` for SQLite compatibility, and standardized naming of primary and foreign key constraints (e.g., `"main_product_pkey"`, `"main_product_price_id_fkey"`). [[1]](diffhunk://#diff-b11d59f4f37d5c27110f48af7426d26832ac758c087a2382793641e1d3d73903L35-R88) [[2]](diffhunk://#diff-538bc6c03c8e140654bd62b0e3294f834dbd20479fd27c2160b579f8a4d796e8L33-R87) [[3]](diffhunk://#diff-538bc6c03c8e140654bd62b0e3294f834dbd20479fd27c2160b579f8a4d796e8L92-R132) [[4]](diffhunk://#diff-068d0ef850a47daa57c57ed65f39dc2630167750de2ab9c0354286bf9fb73569L42-R45)

**Consistency and safety in schema changes:**

* Ensured all new and restored columns in downgrade functions also use `batch_alter_table` and appropriate type variants, preventing migration errors and maintaining consistency between upgrade and downgrade paths. [[1]](diffhunk://#diff-538bc6c03c8e140654bd62b0e3294f834dbd20479fd27c2160b579f8a4d796e8L92-R132) [[2]](diffhunk://#diff-79579e77b41e7908d2e90ce9f4f5f816cf2a460621cf8e5a0dd91d19ecb1cdbbL55-R68) [[3]](diffhunk://#diff-d66e3bd6ca45714e65836d7f3993cbe8403209c836a933c03a531478763c1a7aL35-R41) [[4]](diffhunk://#diff-a299af1145650c4718d50cfe239270a07f0858dfdb244d9cd1ecc4ac20e69995L43-R43) [[5]](diffhunk://#diff-67f51aa5ddbd56567b7a0c5d2b8e8fd4af45707bac04e9aaa664349ec36b625cL43-R43)

These changes make the migration scripts more robust and portable across different database systems, particularly improving support for SQLite during schema evolution.