### PR TITLE
fix: Fix product redirect

### DIFF
--- a/.cursor/rules/js_add_docstring.mdc
+++ b/.cursor/rules/js_add_docstring.mdc
@@ -1,0 +1,73 @@
+---
+description: Add JSDoc docstrings to all functions, methods, and the module in an open JS/JSX/TS/TSX file.
+globs: **/*.{js,jsx,ts,tsx}
+alwaysApply: false
+---
+
+# Add JS/TS Docstrings
+
+When asked to add docstrings to a JS/JSX/TS/TSX file, apply the following rules consistently across the entire file.
+
+## Scope
+
+- Add a file-level docstring at the very top of the file (before imports) if one is missing.
+- Add docstrings to every function, method, arrow function assigned to a variable, and class that lacks one, including constructors, static methods, and getters/setters.
+- Do not remove or rewrite existing docstrings unless explicitly asked.
+
+## Format
+
+Use **JSDoc** style comments (`/** ... */`).
+
+### File docstring
+
+```js
+/**
+ * Short one-line summary of what this module does.
+ */
+```
+
+### Function / method docstring
+
+```js
+/**
+ * Short one-line summary.
+ *
+ * Longer description if the behaviour is non-obvious. Omit when the
+ * one-liner is already sufficient.
+ *
+ * @param {string} name - Description of the argument.
+ * @param {number} [value=0] - Description. Square brackets denote optional.
+ * @returns {string} Description of the return value. Use `void` if nothing is returned.
+ * @throws {Error} Only include when the function body contains an explicit `throw` statement.
+ */
+```
+
+## Section rules
+
+### @param
+- Include **every** parameter.
+- Format: `@param {Type} name - Description.`
+- For TypeScript files, derive the type from the annotation if present; otherwise infer from context.
+- Optional parameters (those with a default value or marked `?`) use square brackets: `@param {Type} [name=default] - Description.`
+- For destructured parameters, document the individual properties: `@param {Type} name.property - Description.`
+
+### @returns
+- Always include this section.
+- Use `@returns {void}` if the function returns nothing meaningful.
+- If the function returns a Promise, use `@returns {Promise<Type>}`.
+
+### @throws
+- **Only** include this section when the function body contains one or more explicit `throw` statements.
+- Do not add this section for exceptions that may propagate from called functions.
+- Format: `@throws {ErrorType} Condition that triggers this error.`
+
+### @example
+- Do **not** add an `@example` section unless the user explicitly requests it.
+
+## Style notes
+
+- Keep the one-line summary under 100 characters and end it with a period.
+- Use present tense ("Return", "Throw", "Parse"), not past tense.
+- Do not repeat what the type annotation already makes obvious — add meaningful context.
+- Preserve all existing code; only insert or update docstring comments.
+- For React components, describe what the component renders, not its implementation details.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expenses-counter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expenses-counter",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expenses-counter",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/cardsStack/CardsStack.tsx
+++ b/frontend/src/components/cardsStack/CardsStack.tsx
@@ -1,20 +1,37 @@
+/**
+ * Renders a category-labeled section with a responsive grid of selectable cards.
+ */
+
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
+import { useMemo } from 'react';
 
 import { Card } from '@components/card';
 import { useCategoryStore } from '@store/category';
 
 import { type ItemType } from './types';
 
+/**
+ * Render a divider with an optional category chip and a grid of cards for each item.
+ *
+ * @param {object} props - Component props.
+ * @param {number | null} props.categoryId - Category used for the section chip label; chip hidden when null.
+ * @param {ItemType[]} props.items - Items to render as cards.
+ * @param {(item: ItemType) => void} props.onClick - Handler invoked when a card is activated.
+ * @returns {JSX.Element} Section with divider and card grid.
+ */
 export function CardsStack(props: {
   categoryId: number | null;
   items: ItemType[];
-  onClick: () => void;
+  onClick: (item: ItemType) => void;
 }) {
   const categories = useCategoryStore((state) => state.categories);
 
-  const category = categories?.find((c) => c.id === props.categoryId);
+  const category = useMemo(
+    () => categories?.find((c) => c.id === props.categoryId),
+    [categories, props.categoryId]
+  );
 
   return (
     <>
@@ -26,7 +43,7 @@ export function CardsStack(props: {
               title={item.name}
               description={item.description}
               icon={item.icon}
-              onClick={props.onClick}
+              onClick={() => props.onClick(item)}
             />
           </Grid>
         ))}

--- a/frontend/src/components/cardsStack/index.ts
+++ b/frontend/src/components/cardsStack/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Re-exports the `CardsStack` component and the `ItemType` shape for card items.
+ */
+
 import { CardsStack } from './CardsStack';
 import { type ItemType } from './types';
 

--- a/frontend/src/components/cardsStack/types.ts
+++ b/frontend/src/components/cardsStack/types.ts
@@ -1,3 +1,15 @@
+/**
+ * Type definitions for `CardsStack` list items.
+ */
+
+/**
+ * Fields required to render an item as a card in the stack grid.
+ *
+ * @property {number} id - Unique key for list rendering and identity.
+ * @property {string} name - Primary label shown on the card.
+ * @property {(string | null)} [description] - Optional secondary text.
+ * @property {(string | null)} [icon] - Optional icon identifier or URL.
+ */
 export type ItemType = {
   id: number;
   name: string;

--- a/frontend/src/pages/product/productList/ProductList.tsx
+++ b/frontend/src/pages/product/productList/ProductList.tsx
@@ -1,3 +1,7 @@
+/**
+ * Product list page: load products and categories, group products by category, and render stacks with navigation to detail and create.
+ */
+
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
@@ -11,6 +15,11 @@ import { useProductAPIClient, useCategoryAPIClient } from '@services/apiClient';
 import { useCategoryStore } from '@store/category';
 import { useProductStore } from '@store/product';
 
+/**
+ * Render products grouped by category as card stacks and a create button.
+ *
+ * @returns {JSX.Element} The product list layout inside a container.
+ */
 export function ProductList() {
   const products = useProductStore((state) => state.products);
   const categories = useCategoryStore((state) => state.categories);
@@ -37,7 +46,7 @@ export function ProductList() {
           key={k}
           categoryId={parseInt(k) ?? null}
           items={productsByCategory[k]}
-          onClick={() => navigate(`/product/${k}`)}
+          onClick={(item) => navigate(`/product/${item.id}`)}
         />
       ))}
       <Box sx={{ display: 'flex', justifyContent: 'end', mt: 2 }}>

--- a/frontend/src/pages/product/productList/index.ts
+++ b/frontend/src/pages/product/productList/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Re-export the product list page component for cleaner imports from the route folder.
+ */
+
 import { ProductList } from './ProductList';
 
 export { ProductList };

--- a/frontend/src/pages/shop/shopList/ShopList.tsx
+++ b/frontend/src/pages/shop/shopList/ShopList.tsx
@@ -1,3 +1,7 @@
+/**
+ * Shop list page: load shops and categories, group shops by category, and render stacks with navigation to detail and create.
+ */
+
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
@@ -11,8 +15,11 @@ import { useShopAPIClient, useCategoryAPIClient } from '@services/apiClient';
 import { useCategoryStore } from '@store/category';
 import { useShopStore } from '@store/shop';
 
-// import { CardsStack } from './cardsStack';
-
+/**
+ * Render shops grouped by category as card stacks and a create button.
+ *
+ * @returns {JSX.Element} The shop list layout inside a container.
+ */
 export function ShopList() {
   const shops = useShopStore((state) => state.shops);
   const categories = useCategoryStore((state) => state.categories);
@@ -39,7 +46,7 @@ export function ShopList() {
           key={k}
           categoryId={parseInt(k) ?? null}
           items={shopsByCategory[k]}
-          onClick={() => navigate(`/shop/${k}`)}
+          onClick={(item) => navigate(`/shop/${item.id}`)}
         />
       ))}
       <Box sx={{ display: 'flex', justifyContent: 'end', mt: 2 }}>

--- a/frontend/src/pages/shop/shopList/index.ts
+++ b/frontend/src/pages/shop/shopList/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Re-export the shop list page component for cleaner imports from the route folder.
+ */
+
 import { ShopList } from './ShopList';
 
 export { ShopList };


### PR DESCRIPTION
This pull request introduces comprehensive JSDoc-style documentation for several frontend components, improves the typing and documentation of the `CardsStack` component, and refines the card click handling logic for both the product and shop list pages. It also bumps the frontend package version.

**Documentation improvements:**

- Added a new documentation rule file `.cursor/rules/js_add_docstring.mdc` to standardize JSDoc docstring usage across JS/TS files.
- Added JSDoc docstrings to the `CardsStack` component (`CardsStack.tsx`), its type definitions (`types.ts`), and re-export files for better code clarity and maintainability. [[1]](diffhunk://#diff-19d3fff9481c67851d1372fb0ddb3cb7e769091a4a5fc1cbff7146ce4afcf95bR1-R34) [[2]](diffhunk://#diff-5fd2b29adabfdb4a49faf9ce144c55633753bb7241a4ba77997d9eed26bf9760R1-R4) [[3]](diffhunk://#diff-3d114005b62a5db1debbddd51fe1ca6976c305b706888362c46d04187e8bf2b7R1-R12)
- Added JSDoc docstrings to the `ProductList` and `ShopList` page components and their respective re-export files. [[1]](diffhunk://#diff-851d697e7bcc003d45f3d502b440fb78dccb4ca7b53c32904a34ba6c108d95f5R1-R4) [[2]](diffhunk://#diff-ce43dc108c88517fd747deae264231ddbb6966a53fea7e4bd888b0c78bd5e32dR1-R4) [[3]](diffhunk://#diff-c219fdb3e7e19b0a46ad933f5059e9fd0ea101e043c171c5ca4a26678f502c1bR1-R4) [[4]](diffhunk://#diff-5a7fb2f80c9e01f96c7a2c00aa5120b10cf17ee26a705265eecfff4bdd6d9021R1-R4)

**Component and typing enhancements:**

- Improved the `CardsStack` component by updating its `onClick` prop to provide the clicked `ItemType` object, enabling more flexible card click handling.
- Updated the usage of `CardsStack` in both `ProductList` and `ShopList` pages to navigate to the detail page of the clicked item, rather than using a category-based navigation. [[1]](diffhunk://#diff-851d697e7bcc003d45f3d502b440fb78dccb4ca7b53c32904a34ba6c108d95f5L40-R49) [[2]](diffhunk://#diff-c219fdb3e7e19b0a46ad933f5059e9fd0ea101e043c171c5ca4a26678f502c1bL42-R49)
- Enhanced type documentation for `ItemType` in `cardsStack/types.ts`.

**Versioning:**

- Bumped the frontend package version from `1.0.4` to `1.0.5`.