### PR TITLE
feat: Add lazy loading for fe pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expenses-counter",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,30 +1,51 @@
+/**
+ * Root application shell: navigation bar, React Router routes, and lazy-loaded page bundles behind Suspense.
+ */
 import { Navbar } from '@components';
-import { Home, ShopList, CreateShop, TransactionPage, Login } from '@pages';
-import { ProductList, CreateProduct } from '@pages/product';
+import { lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router';
 
+const Home = lazy(() => import('@pages/home').then((m) => ({ default: m.Home })));
+const Login = lazy(() => import('@pages/login').then((m) => ({ default: m.Login })));
+const ShopList = lazy(() => import('@pages/shop').then((m) => ({ default: m.ShopList })));
+const CreateShop = lazy(() => import('@pages/shop').then((m) => ({ default: m.CreateShop })));
+const ProductList = lazy(() => import('@pages/product').then((m) => ({ default: m.ProductList })));
+const CreateProduct = lazy(() =>
+  import('@pages/product').then((m) => ({ default: m.CreateProduct }))
+);
+const TransactionPage = lazy(() =>
+  import('@pages/transaction').then((m) => ({ default: m.TransactionPage }))
+);
+
+/**
+ * Wires URL paths to page components: home, login, nested shop/product CRUD routes, and transaction views.
+ *
+ * @returns {JSX.Element} Navbar plus routed lazy content (no visible Suspense fallback).
+ */
 function App() {
   return (
     <>
       <Navbar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/shop">
-          <Route index element={<ShopList />} />
-          <Route path="create" element={<CreateShop />} />
-          <Route path=":shopId" element={<CreateShop />} />
-        </Route>
-        <Route path="/product">
-          <Route index element={<ProductList />} />
-          <Route path="create" element={<CreateProduct />} />
-          <Route path=":productId" element={<CreateProduct />} />
-        </Route>
-        <Route path="/transaction">
-          <Route index element={<TransactionPage />} />
-          <Route path=":transactionId" element={<TransactionPage />} />
-        </Route>
-      </Routes>
+      <Suspense fallback={null}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/shop">
+            <Route index element={<ShopList />} />
+            <Route path="create" element={<CreateShop />} />
+            <Route path=":shopId" element={<CreateShop />} />
+          </Route>
+          <Route path="/product">
+            <Route index element={<ProductList />} />
+            <Route path="create" element={<CreateProduct />} />
+            <Route path=":productId" element={<CreateProduct />} />
+          </Route>
+          <Route path="/transaction">
+            <Route index element={<TransactionPage />} />
+            <Route path=":transactionId" element={<TransactionPage />} />
+          </Route>
+        </Routes>
+      </Suspense>
     </>
   );
 }


### PR DESCRIPTION
This pull request focuses on optimizing the way page components are loaded in the application, improving performance by leveraging React's lazy loading and code splitting. Instead of importing all page components up front, the app now loads them only when needed, reducing the initial bundle size and speeding up the initial load time.

**Performance improvements via code splitting:**

* Switched from static imports to `React.lazy` for all main page components (e.g., `Home`, `Login`, `ShopList`, `CreateShop`, `ProductList`, `CreateProduct`, `TransactionPage`), so each page is loaded only when its route is accessed.
* Wrapped the routed content in a `Suspense` boundary with a `null` fallback to handle the loading state during code splitting.

**Other changes:**

* Updated the application version in `package.json` from `1.2.0` to `1.2.1` to reflect these improvements.