### PR TITLE
feat: Use admin

### DIFF
--- a/backend/src/expenses_counter/__init__.py
+++ b/backend/src/expenses_counter/__init__.py
@@ -1,3 +1,3 @@
 """Expenses counter package."""
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"

--- a/backend/src/expenses_counter/modules/routers/api/v1/address.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/address.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import IntegrityError, NoResultFound, SQLAlchemyError
 
 from expenses_counter.modules.middlewares.dependencies.admin_required import admin_required
 from expenses_counter.modules.middlewares.dependencies.daos.get_address import get_address
+from expenses_counter.modules.middlewares.dependencies.user_authorized import user_authorized
 from expenses_counter.modules.routers.schemas.base.metadata import PaginationMetadata
 from expenses_counter.modules.routers.schemas.requests.address import (
     GetAllAddressesQuery,
@@ -37,7 +38,7 @@ from expenses_counter.modules.routers.schemas.responses.address import (
 )
 from expenses_counter.services.daos import AddressDAO
 
-router = APIRouter(prefix="/address", tags=["Address"], dependencies=[Depends(admin_required)])
+router = APIRouter(prefix="/address", tags=["Address"], dependencies=[Depends(user_authorized)])
 
 
 @router.get("", response_model=GetAllAddressesResponse, status_code=status.HTTP_200_OK)
@@ -106,7 +107,12 @@ async def get_address_by_local_name(
     return GetSingleAddressResponse.model_validate(payload)
 
 
-@router.get("/{address_id}", response_model=GetSingleAddressResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "/{address_id}",
+    response_model=GetSingleAddressResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def get_address_by_id(
     address_id: Annotated[int, Path(description="The unique identifier of the address to retrieve")],
     address_dao: Annotated[AddressDAO, Depends(get_address)],
@@ -139,7 +145,12 @@ async def get_address_by_id(
     return GetSingleAddressResponse.model_validate(payload)
 
 
-@router.post("", response_model=GetSingleAddressResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=GetSingleAddressResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(admin_required)],
+)
 async def create_address(
     body: Annotated[PostAddressBody, Body(description="The address data to create")],
     address_dao: Annotated[AddressDAO, Depends(get_address)],
@@ -172,7 +183,12 @@ async def create_address(
     return GetSingleAddressResponse.model_validate(payload)
 
 
-@router.put("/{address_id}", response_model=GetSingleAddressResponse, status_code=status.HTTP_200_OK)
+@router.put(
+    "/{address_id}",
+    response_model=GetSingleAddressResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def update_address(
     address_id: Annotated[int, Path(description="The unique identifier of the address to update")],
     body: Annotated[PutAddressBody, Body(description="The address data to update")],
@@ -210,7 +226,12 @@ async def update_address(
     return GetSingleAddressResponse.model_validate(payload)
 
 
-@router.patch("/{address_id}", response_model=GetSingleAddressResponse, status_code=status.HTTP_200_OK)
+@router.patch(
+    "/{address_id}",
+    response_model=GetSingleAddressResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def patch_address(
     address_id: Annotated[int, Path(description="The unique identifier of the address to update")],
     body: Annotated[PatchAddressBody, Body(description="The address data to update")],
@@ -248,7 +269,7 @@ async def patch_address(
     return GetSingleAddressResponse.model_validate(payload)
 
 
-@router.delete("/{address_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{address_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_required)])
 async def delete_address(
     address_id: Annotated[int, Path(description="The unique identifier of the address to delete")],
     address_dao: Annotated[AddressDAO, Depends(get_address)],

--- a/backend/src/expenses_counter/modules/routers/api/v1/address.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/address.py
@@ -21,8 +21,8 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from loguru import logger
 from sqlalchemy.exc import IntegrityError, NoResultFound, SQLAlchemyError
 
+from expenses_counter.modules.middlewares.dependencies.admin_required import admin_required
 from expenses_counter.modules.middlewares.dependencies.daos.get_address import get_address
-from expenses_counter.modules.middlewares.dependencies.user_authorized import user_authorized
 from expenses_counter.modules.routers.schemas.base.metadata import PaginationMetadata
 from expenses_counter.modules.routers.schemas.requests.address import (
     GetAllAddressesQuery,
@@ -37,7 +37,7 @@ from expenses_counter.modules.routers.schemas.responses.address import (
 )
 from expenses_counter.services.daos import AddressDAO
 
-router = APIRouter(prefix="/address", tags=["Address"], dependencies=[Depends(user_authorized)])
+router = APIRouter(prefix="/address", tags=["Address"], dependencies=[Depends(admin_required)])
 
 
 @router.get("", response_model=GetAllAddressesResponse, status_code=status.HTTP_200_OK)

--- a/backend/src/expenses_counter/modules/routers/api/v1/category.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/category.py
@@ -147,7 +147,12 @@ async def get_category_list_by_parent(
     )
 
 
-@router.get("/{category_id}", response_model=GetSingleCategoryResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "/{category_id}",
+    response_model=GetSingleCategoryResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def get_category_by_id(
     category_id: Annotated[int, Path(description="The unique identifier of the category to retrieve")],
     category_dao: Annotated[CategoryDAO, Depends(get_category)],
@@ -181,7 +186,12 @@ async def get_category_by_id(
     return GetSingleCategoryResponse.model_validate(payload)
 
 
-@router.post("", response_model=GetSingleCategoryResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=GetSingleCategoryResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(admin_required)],
+)
 async def create_category(
     body: Annotated[PostCategoryBody, Body(description="The category data to create")],
     category_dao: Annotated[CategoryDAO, Depends(get_category)],
@@ -214,7 +224,12 @@ async def create_category(
     return GetSingleCategoryResponse.model_validate(payload)
 
 
-@router.put("/{category_id}", response_model=GetSingleCategoryResponse, status_code=status.HTTP_200_OK)
+@router.put(
+    "/{category_id}",
+    response_model=GetSingleCategoryResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def update_category(
     category_id: Annotated[int, Path(description="The unique identifier of the category to update")],
     body: Annotated[PutCategoryBody, Body(description="The category data to update")],
@@ -253,7 +268,12 @@ async def update_category(
     return GetSingleCategoryResponse.model_validate(payload)
 
 
-@router.patch("/{category_id}", response_model=GetSingleCategoryResponse, status_code=status.HTTP_200_OK)
+@router.patch(
+    "/{category_id}",
+    response_model=GetSingleCategoryResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def patch_category(
     category_id: Annotated[int, Path(description="The unique identifier of the category to update")],
     body: Annotated[PatchCategoryBody, Body(description="The category data to update")],
@@ -292,7 +312,7 @@ async def patch_category(
     return GetSingleCategoryResponse.model_validate(payload)
 
 
-@router.delete("/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{category_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_required)])
 async def delete_category(
     category_id: Annotated[int, Path(description="The unique identifier of the category to delete")],
     category_dao: Annotated[CategoryDAO, Depends(get_category)],

--- a/backend/src/expenses_counter/modules/routers/api/v1/category.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/category.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import IntegrityError, NoResultFound, SQLAlchemyError
 
 from expenses_counter.modules.middlewares.dependencies.admin_required import admin_required
 from expenses_counter.modules.middlewares.dependencies.daos import get_category
+from expenses_counter.modules.middlewares.dependencies.user_authorized import user_authorized
 from expenses_counter.modules.routers.schemas.base.metadata import PaginationMetadata
 from expenses_counter.modules.routers.schemas.requests.category import (
     GetAllCategoriesByParentQuery,
@@ -39,7 +40,7 @@ from expenses_counter.modules.routers.schemas.responses.category import (
 from expenses_counter.services.daos import CategoryDAO
 from expenses_counter.utils.filter import Filter
 
-router = APIRouter(prefix="/category", tags=["Category"], dependencies=[Depends(admin_required)])
+router = APIRouter(prefix="/category", tags=["Category"], dependencies=[Depends(user_authorized)])
 
 
 @router.get("", response_model=GetAllCategoriesResponse, status_code=status.HTTP_200_OK)

--- a/backend/src/expenses_counter/modules/routers/api/v1/category.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/category.py
@@ -21,8 +21,8 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from loguru import logger
 from sqlalchemy.exc import IntegrityError, NoResultFound, SQLAlchemyError
 
+from expenses_counter.modules.middlewares.dependencies.admin_required import admin_required
 from expenses_counter.modules.middlewares.dependencies.daos import get_category
-from expenses_counter.modules.middlewares.dependencies.user_authorized import user_authorized
 from expenses_counter.modules.routers.schemas.base.metadata import PaginationMetadata
 from expenses_counter.modules.routers.schemas.requests.category import (
     GetAllCategoriesByParentQuery,
@@ -39,7 +39,7 @@ from expenses_counter.modules.routers.schemas.responses.category import (
 from expenses_counter.services.daos import CategoryDAO
 from expenses_counter.utils.filter import Filter
 
-router = APIRouter(prefix="/category", tags=["Category"], dependencies=[Depends(user_authorized)])
+router = APIRouter(prefix="/category", tags=["Category"], dependencies=[Depends(admin_required)])
 
 
 @router.get("", response_model=GetAllCategoriesResponse, status_code=status.HTTP_200_OK)

--- a/backend/src/expenses_counter/modules/routers/api/v1/product.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/product.py
@@ -31,8 +31,8 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from loguru import logger
 from sqlalchemy.exc import IntegrityError, NoResultFound, SQLAlchemyError
 
+from expenses_counter.modules.middlewares.dependencies.admin_required import admin_required
 from expenses_counter.modules.middlewares.dependencies.daos import get_product
-from expenses_counter.modules.middlewares.dependencies.user_authorized import user_authorized
 from expenses_counter.modules.routers.schemas.base.metadata import PaginationMetadata
 from expenses_counter.modules.routers.schemas.requests.product import (
     GetAllProductsQuery,
@@ -47,7 +47,7 @@ from expenses_counter.modules.routers.schemas.responses.product import (
 )
 from expenses_counter.services.daos import ProductDAO
 
-router = APIRouter(prefix="/product", tags=["Product"], dependencies=[Depends(user_authorized)])
+router = APIRouter(prefix="/product", tags=["Product"], dependencies=[Depends(admin_required)])
 
 
 @router.get("", response_model=GetAllProductsResponse, status_code=status.HTTP_200_OK)

--- a/backend/src/expenses_counter/modules/routers/api/v1/product.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/product.py
@@ -83,7 +83,12 @@ async def get_product_list(
     )
 
 
-@router.get("/{product_id}", response_model=GetSingleProductResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "/{product_id}",
+    response_model=GetSingleProductResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def get_product_by_id(
     product_id: Annotated[int, Path(description="The unique identifier of the product to retrieve")],
     product_dao: Annotated[ProductDAO, Depends(get_product)],
@@ -117,7 +122,12 @@ async def get_product_by_id(
     return GetSingleProductResponse.model_validate(payload)
 
 
-@router.post("", response_model=GetSingleProductResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=GetSingleProductResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(admin_required)],
+)
 async def create_product(
     body: Annotated[PostProductBody, Body(description="The product data to create")],
     product_dao: Annotated[ProductDAO, Depends(get_product)],
@@ -151,7 +161,12 @@ async def create_product(
     return GetSingleProductResponse.model_validate(payload)
 
 
-@router.put("/{product_id}", response_model=GetSingleProductResponse, status_code=status.HTTP_200_OK)
+@router.put(
+    "/{product_id}",
+    response_model=GetSingleProductResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def update_product(
     product_id: Annotated[int, Path(description="The unique identifier of the product to update")],
     body: Annotated[PutProductBody, Body(description="The product data to update")],
@@ -191,7 +206,12 @@ async def update_product(
     return GetSingleProductResponse.model_validate(payload)
 
 
-@router.patch("/{product_id}", response_model=GetSingleProductResponse, status_code=status.HTTP_200_OK)
+@router.patch(
+    "/{product_id}",
+    response_model=GetSingleProductResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def patch_product(
     product_id: Annotated[int, Path(description="The unique identifier of the product to update")],
     body: Annotated[PatchProductBody, Body(description="The product data to update")],
@@ -231,7 +251,7 @@ async def patch_product(
     return GetSingleProductResponse.model_validate(payload)
 
 
-@router.delete("/{product_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{product_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_required)])
 async def delete_product(
     product_id: Annotated[int, Path(description="The unique identifier of the product to delete")],
     product_dao: Annotated[ProductDAO, Depends(get_product)],

--- a/backend/src/expenses_counter/modules/routers/api/v1/product.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/product.py
@@ -33,6 +33,7 @@ from sqlalchemy.exc import IntegrityError, NoResultFound, SQLAlchemyError
 
 from expenses_counter.modules.middlewares.dependencies.admin_required import admin_required
 from expenses_counter.modules.middlewares.dependencies.daos import get_product
+from expenses_counter.modules.middlewares.dependencies.user_authorized import user_authorized
 from expenses_counter.modules.routers.schemas.base.metadata import PaginationMetadata
 from expenses_counter.modules.routers.schemas.requests.product import (
     GetAllProductsQuery,
@@ -47,7 +48,7 @@ from expenses_counter.modules.routers.schemas.responses.product import (
 )
 from expenses_counter.services.daos import ProductDAO
 
-router = APIRouter(prefix="/product", tags=["Product"], dependencies=[Depends(admin_required)])
+router = APIRouter(prefix="/product", tags=["Product"], dependencies=[Depends(user_authorized)])
 
 
 @router.get("", response_model=GetAllProductsResponse, status_code=status.HTTP_200_OK)

--- a/backend/src/expenses_counter/modules/routers/api/v1/shop.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/shop.py
@@ -69,11 +69,11 @@ async def get_shop_list(
     return GetAllShopsResponse(data=[SimpleShopGet.model_validate(shop) for shop in data], metadata=metadata)
 
 
-@router.get("/{shop_id}", response_model=GetSingleShopResponse)
+@router.get("/{shop_id}", response_model=GetSingleShopResponse, dependencies=[Depends(admin_required)])
 async def get_shop_by_id(
     shop_id: Annotated[int, Path(description="The unique identifier of the shop to retrieve")],
     shop_dao: Annotated[ShopDAO, Depends(get_shop)],
-):
+) -> GetSingleShopResponse:
     """Return a single shop by primary key.
 
     Args:
@@ -103,7 +103,12 @@ async def get_shop_by_id(
     return GetSingleShopResponse.model_validate(payload)
 
 
-@router.post("", response_model=GetSingleShopResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=GetSingleShopResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(admin_required)],
+)
 async def create_shop(
     body: Annotated[PostShopBody, Body(description="The shop data to create")],
     shop_dao: Annotated[ShopDAO, Depends(get_shop)],
@@ -137,7 +142,12 @@ async def create_shop(
     return GetSingleShopResponse.model_validate(payload)
 
 
-@router.put("/{shop_id}", response_model=GetSingleShopResponse, status_code=status.HTTP_200_OK)
+@router.put(
+    "/{shop_id}",
+    response_model=GetSingleShopResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def update_shop(
     shop_id: Annotated[int, Path(description="The unique identifier of the shop to update")],
     body: Annotated[PutShopBody, Body(description="The shop data to update")],
@@ -177,7 +187,12 @@ async def update_shop(
     return GetSingleShopResponse.model_validate(payload)
 
 
-@router.patch("/{shop_id}", response_model=GetSingleShopResponse, status_code=status.HTTP_200_OK)
+@router.patch(
+    "/{shop_id}",
+    response_model=GetSingleShopResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(admin_required)],
+)
 async def patch_shop(
     shop_id: Annotated[int, Path(description="The unique identifier of the shop to update")],
     body: Annotated[PatchShopBody, Body(description="The shop data to update")],
@@ -217,7 +232,7 @@ async def patch_shop(
     return GetSingleShopResponse.model_validate(payload)
 
 
-@router.delete("/{shop_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{shop_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(admin_required)])
 async def delete_shop(
     shop_id: Annotated[int, Path(description="The unique identifier of the shop to delete")],
     shop_dao: Annotated[ShopDAO, Depends(get_shop)],

--- a/backend/src/expenses_counter/modules/routers/api/v1/shop.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/shop.py
@@ -19,8 +19,8 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from loguru import logger
 from sqlalchemy.exc import IntegrityError, NoResultFound, SQLAlchemyError
 
+from expenses_counter.modules.middlewares.dependencies.admin_required import admin_required
 from expenses_counter.modules.middlewares.dependencies.daos import get_shop
-from expenses_counter.modules.middlewares.dependencies.user_authorized import user_authorized
 from expenses_counter.modules.routers.schemas.base.metadata import PaginationMetadata
 from expenses_counter.modules.routers.schemas.requests.shop import (
     GetAllShopsQuery,
@@ -35,7 +35,7 @@ from expenses_counter.modules.routers.schemas.responses.shop import (
 )
 from expenses_counter.services.daos import ShopDAO
 
-router = APIRouter(prefix="/shop", tags=["Shop"], dependencies=[Depends(user_authorized)])
+router = APIRouter(prefix="/shop", tags=["Shop"], dependencies=[Depends(admin_required)])
 
 
 @router.get("", response_model=GetAllShopsResponse, status_code=status.HTTP_200_OK)

--- a/backend/src/expenses_counter/modules/routers/api/v1/shop.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/shop.py
@@ -21,6 +21,7 @@ from sqlalchemy.exc import IntegrityError, NoResultFound, SQLAlchemyError
 
 from expenses_counter.modules.middlewares.dependencies.admin_required import admin_required
 from expenses_counter.modules.middlewares.dependencies.daos import get_shop
+from expenses_counter.modules.middlewares.dependencies.user_authorized import user_authorized
 from expenses_counter.modules.routers.schemas.base.metadata import PaginationMetadata
 from expenses_counter.modules.routers.schemas.requests.shop import (
     GetAllShopsQuery,
@@ -35,7 +36,7 @@ from expenses_counter.modules.routers.schemas.responses.shop import (
 )
 from expenses_counter.services.daos import ShopDAO
 
-router = APIRouter(prefix="/shop", tags=["Shop"], dependencies=[Depends(admin_required)])
+router = APIRouter(prefix="/shop", tags=["Shop"], dependencies=[Depends(user_authorized)])
 
 
 @router.get("", response_model=GetAllShopsResponse, status_code=status.HTTP_200_OK)

--- a/backend/src/expenses_counter/modules/routers/api/v1/user.py
+++ b/backend/src/expenses_counter/modules/routers/api/v1/user.py
@@ -7,6 +7,7 @@ Routes:
     GET /user/me - Get the current user
     PUT /user - Replace the current user's fields
     PATCH /user - Partially update the current user
+    GET /user/available-pages - Page keys the user may access
 """
 
 __all__ = ("router",)
@@ -137,3 +138,28 @@ async def patch_me(
         ) from e
 
     return GetSingleUserResponse.model_validate(payload)
+
+
+@router.get(
+    "/available-pages",
+    response_model=list[str],
+    status_code=status.HTTP_200_OK,
+    description="Get the available pages",
+)
+async def get_available_pages(user: Annotated[User, Depends(user_authorized)]) -> list[str]:
+    """Return route page identifiers the authenticated user is allowed to open.
+
+    Admin users receive identifiers for admin-only sections; non-admins get an
+    empty list.
+
+    Args:
+        user (User): The user resolved from the JWT by ``user_authorized``.
+
+    Returns:
+        list[str]: Page keys (e.g. ``shops``, ``products``) or an empty list.
+
+    """
+    if user.is_admin:
+        return ["shops", "products"]
+
+    return []

--- a/backend/src/expenses_counter/services/alembic/migrations/versions/2026-05-14_20-42_06e92c9e6a09_add_first_last_name_is_admin_photo_url_.py
+++ b/backend/src/expenses_counter/services/alembic/migrations/versions/2026-05-14_20-42_06e92c9e6a09_add_first_last_name_is_admin_photo_url_.py
@@ -32,8 +32,8 @@ def upgrade():
     with op.batch_alter_table("main_user") as batch_op:
         batch_op.add_column(sa.Column("first_name", sa.String(150), nullable=True))
         batch_op.add_column(sa.Column("last_name", sa.String(150), nullable=True))
-        batch_op.add_column(sa.Column("is_admin", sa.Boolean, nullable=False, server_default="false"))
-        batch_op.add_column(sa.Column("is_active", sa.Boolean, nullable=False, server_default="true"))
+        batch_op.add_column(sa.Column("is_admin", sa.Boolean, nullable=False, server_default="0"))
+        batch_op.add_column(sa.Column("is_active", sa.Boolean, nullable=False, server_default="1"))
         batch_op.add_column(sa.Column("photo_url", sa.String(255), nullable=True))
 
 

--- a/backend/tests/api/test_admin_required.py
+++ b/backend/tests/api/test_admin_required.py
@@ -1,16 +1,17 @@
 """API tests for the ``admin_required`` gate on ``/api/v1`` routers.
 
-The category, product, and shop routers are admin-only end-to-end. The address
-router applies ``admin_required`` to every endpoint except the two list/lookup
-reads (``GET /address`` and ``GET /address/name/{local_name}``). This module
-exercises a request per admin-protected ``(method, path)`` pair with an
-authenticated non-admin user and asserts the dependency rejects it with 403.
+The address, category, shop, and product routers require ``user_authorized``
+at the router level. ``admin_required`` is applied per-endpoint to the write
+operations and per-item reads, while list endpoints remain open to any
+authenticated user. This module verifies both halves of that contract: a
+non-admin user gets 403 on admin-gated routes and 200 on the user-only ones.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import NoResultFound
 
 from expenses_counter.modules.app import get_app
 from expenses_counter.modules.middlewares.dependencies import user_authorized
@@ -25,21 +26,16 @@ from expenses_counter.modules.middlewares.dependencies.daos import (
 # minimal — the gate fires before request validation, so a 403 must come back
 # regardless of payload shape.
 ADMIN_PROTECTED_ROUTES: list[tuple[str, str]] = [
-    ("GET", "/api/v1/category"),
     ("GET", "/api/v1/category/1"),
-    ("GET", "/api/v1/category/parent"),
-    ("GET", "/api/v1/category/parent/1"),
     ("POST", "/api/v1/category"),
     ("PUT", "/api/v1/category/1"),
     ("PATCH", "/api/v1/category/1"),
     ("DELETE", "/api/v1/category/1"),
-    ("GET", "/api/v1/shop"),
     ("GET", "/api/v1/shop/1"),
     ("POST", "/api/v1/shop"),
     ("PUT", "/api/v1/shop/1"),
     ("PATCH", "/api/v1/shop/1"),
     ("DELETE", "/api/v1/shop/1"),
-    ("GET", "/api/v1/product"),
     ("GET", "/api/v1/product/1"),
     ("POST", "/api/v1/product"),
     ("PUT", "/api/v1/product/1"),
@@ -52,10 +48,28 @@ ADMIN_PROTECTED_ROUTES: list[tuple[str, str]] = [
     ("DELETE", "/api/v1/address/1"),
 ]
 
+# (method, path) pairs that only require ``user_authorized`` — a non-admin
+# user must reach the handler. The DAO mocks resolve list calls to an empty
+# page so handlers serialize a valid response.
+USER_ONLY_ROUTES: list[tuple[str, str]] = [
+    ("GET", "/api/v1/category"),
+    ("GET", "/api/v1/category/parent"),
+    ("GET", "/api/v1/category/parent/1"),
+    ("GET", "/api/v1/shop"),
+    ("GET", "/api/v1/product"),
+    ("GET", "/api/v1/address"),
+]
+
 
 def _async_dao_mock() -> AsyncMock:
-    """Return a generic async DAO mock for routes that resolve a DAO dependency."""
+    """Return a generic async DAO mock for routes that resolve a DAO dependency.
+
+    ``get_all`` returns an empty paginated result so list handlers can
+    serialize a 200 response without needing a real database row.
+
+    """
     dao = AsyncMock()
+    dao.get_all = AsyncMock(return_value=([], 0))
     dao.__aenter__ = AsyncMock(return_value=dao)
     dao.__aexit__ = AsyncMock(return_value=None)
     return dao
@@ -104,6 +118,27 @@ class TestAdminRequiredRejectsNonAdmin:
 
 
 @pytest.mark.api
+class TestUserOnlyRoutesAllowNonAdmin:
+    """Non-admin users must be allowed through routes without ``admin_required``."""
+
+    @pytest.mark.parametrize(("method", "path"), USER_ONLY_ROUTES)
+    def test_non_admin_reaches_handler(self, non_admin_client: TestClient, method: str, path: str) -> None:
+        """The gate skips these routes — handler must return 200 for an authenticated user."""
+        response = non_admin_client.request(method, path)
+        assert response.status_code == 200
+
+    def test_non_admin_can_look_up_address_by_local_name(self, non_admin_client: TestClient) -> None:
+        """Address-by-local-name lookup is user-only; 404 confirms the handler ran."""
+        dao = _async_dao_mock()
+        # 404 is fine — what matters is we are not blocked by ``admin_required``.
+        dao.get_by_address = AsyncMock(side_effect=NoResultFound("Address not found"))
+        non_admin_client.app.dependency_overrides[get_address] = lambda: dao
+
+        response = non_admin_client.get("/api/v1/address/name/unknown")
+        assert response.status_code == 404
+
+
+@pytest.mark.api
 class TestAdminRequiredAllowsAdmin:
     """Admin users must pass the gate (handler-level outcome is not asserted)."""
 
@@ -122,7 +157,7 @@ class TestAdminRequiredAllowsAdmin:
         app = get_app(test_config)
 
         category_dao = _async_dao_mock()
-        category_dao.get_all = AsyncMock(return_value=([], 0))
+        category_dao.get_by_pk = AsyncMock(side_effect=NoResultFound("Category not found"))
 
         app.dependency_overrides[user_authorized] = lambda: mock_user
         app.dependency_overrides[get_category] = lambda: category_dao
@@ -133,38 +168,10 @@ class TestAdminRequiredAllowsAdmin:
         app.dependency_overrides.clear()
 
     def test_admin_passes_admin_required_gate(self, admin_client: TestClient) -> None:
-        """An admin reaches the handler — the gate must not short-circuit with 403."""
-        response = admin_client.get("/api/v1/category")
-        assert response.status_code == 200
+        """An admin reaches an admin-only handler — the gate must not short-circuit with 403.
 
-
-@pytest.mark.api
-class TestAddressPublicReadsAllowedForNonAdmin:
-    """``GET /address`` and ``GET /address/name/{local_name}`` skip the admin gate."""
-
-    def test_non_admin_can_list_addresses(self, non_admin_client: TestClient) -> None:
-        """Listing addresses must remain available to authenticated non-admin users."""
-        # The injected address DAO is a bare AsyncMock; override its get_all to
-        # return an empty page so the handler can serialize a valid response.
-        from expenses_counter.modules.middlewares.dependencies.daos import get_address as _get_address
-
-        dao = _async_dao_mock()
-        dao.get_all = AsyncMock(return_value=([], 0))
-        non_admin_client.app.dependency_overrides[_get_address] = lambda: dao
-
-        response = non_admin_client.get("/api/v1/address")
-        assert response.status_code == 200
-
-    def test_non_admin_can_look_up_address_by_local_name(self, non_admin_client: TestClient) -> None:
-        """Resolving an address by local name must not require admin privileges."""
-        from sqlalchemy.exc import NoResultFound
-
-        from expenses_counter.modules.middlewares.dependencies.daos import get_address as _get_address
-
-        dao = _async_dao_mock()
-        # 404 is fine — what matters is we are not blocked by ``admin_required``.
-        dao.get_by_address = AsyncMock(side_effect=NoResultFound("Address not found"))
-        non_admin_client.app.dependency_overrides[_get_address] = lambda: dao
-
-        response = non_admin_client.get("/api/v1/address/name/unknown")
+        ``GET /category/{id}`` is admin-gated; we route it through to a 404 from the DAO
+        to prove the request passed ``admin_required`` rather than being blocked at the gate.
+        """
+        response = admin_client.get("/api/v1/category/1")
         assert response.status_code == 404

--- a/backend/tests/api/test_admin_required.py
+++ b/backend/tests/api/test_admin_required.py
@@ -1,0 +1,170 @@
+"""API tests for the ``admin_required`` gate on ``/api/v1`` routers.
+
+The category, product, and shop routers are admin-only end-to-end. The address
+router applies ``admin_required`` to every endpoint except the two list/lookup
+reads (``GET /address`` and ``GET /address/name/{local_name}``). This module
+exercises a request per admin-protected ``(method, path)`` pair with an
+authenticated non-admin user and asserts the dependency rejects it with 403.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from expenses_counter.modules.app import get_app
+from expenses_counter.modules.middlewares.dependencies import user_authorized
+from expenses_counter.modules.middlewares.dependencies.daos import (
+    get_address,
+    get_category,
+    get_product,
+    get_shop,
+)
+
+# (method, path) pairs guarded by ``admin_required``. Bodies are intentionally
+# minimal — the gate fires before request validation, so a 403 must come back
+# regardless of payload shape.
+ADMIN_PROTECTED_ROUTES: list[tuple[str, str]] = [
+    ("GET", "/api/v1/category"),
+    ("GET", "/api/v1/category/1"),
+    ("GET", "/api/v1/category/parent"),
+    ("GET", "/api/v1/category/parent/1"),
+    ("POST", "/api/v1/category"),
+    ("PUT", "/api/v1/category/1"),
+    ("PATCH", "/api/v1/category/1"),
+    ("DELETE", "/api/v1/category/1"),
+    ("GET", "/api/v1/shop"),
+    ("GET", "/api/v1/shop/1"),
+    ("POST", "/api/v1/shop"),
+    ("PUT", "/api/v1/shop/1"),
+    ("PATCH", "/api/v1/shop/1"),
+    ("DELETE", "/api/v1/shop/1"),
+    ("GET", "/api/v1/product"),
+    ("GET", "/api/v1/product/1"),
+    ("POST", "/api/v1/product"),
+    ("PUT", "/api/v1/product/1"),
+    ("PATCH", "/api/v1/product/1"),
+    ("DELETE", "/api/v1/product/1"),
+    ("GET", "/api/v1/address/1"),
+    ("POST", "/api/v1/address"),
+    ("PUT", "/api/v1/address/1"),
+    ("PATCH", "/api/v1/address/1"),
+    ("DELETE", "/api/v1/address/1"),
+]
+
+
+def _async_dao_mock() -> AsyncMock:
+    """Return a generic async DAO mock for routes that resolve a DAO dependency."""
+    dao = AsyncMock()
+    dao.__aenter__ = AsyncMock(return_value=dao)
+    dao.__aexit__ = AsyncMock(return_value=None)
+    return dao
+
+
+@pytest.fixture
+def non_admin_client(mock_non_admin_user, test_config):
+    """Return a ``TestClient`` authenticated as a non-admin user.
+
+    DAO dependencies are stubbed so request resolution does not require a
+    live database; the assertion is purely that ``admin_required`` rejects
+    the request before any DAO method is invoked.
+
+    Args:
+        mock_non_admin_user: Mock ``User`` with ``is_admin=False``.
+        test_config: Test configuration fixture.
+
+    Yields:
+        TestClient: Client whose ``user_authorized`` returns a non-admin user.
+
+    """
+    app = get_app(test_config)
+
+    app.dependency_overrides[user_authorized] = lambda: mock_non_admin_user
+    app.dependency_overrides[get_category] = lambda: _async_dao_mock()
+    app.dependency_overrides[get_shop] = lambda: _async_dao_mock()
+    app.dependency_overrides[get_product] = lambda: _async_dao_mock()
+    app.dependency_overrides[get_address] = lambda: _async_dao_mock()
+
+    client = TestClient(app)
+    yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.api
+class TestAdminRequiredRejectsNonAdmin:
+    """Non-admin users must be rejected from admin-only endpoints with 403."""
+
+    @pytest.mark.parametrize(("method", "path"), ADMIN_PROTECTED_ROUTES)
+    def test_non_admin_is_forbidden(self, non_admin_client: TestClient, method: str, path: str) -> None:
+        """Authenticated but non-admin requests must surface ``admin_required``'s 403."""
+        response = non_admin_client.request(method, path, json={})
+        assert response.status_code == 403
+        assert response.json()["detail"] == "You are not authorized to access this resource"
+
+
+@pytest.mark.api
+class TestAdminRequiredAllowsAdmin:
+    """Admin users must pass the gate (handler-level outcome is not asserted)."""
+
+    @pytest.fixture
+    def admin_client(self, mock_user, test_config):
+        """Return a ``TestClient`` authenticated as an admin user.
+
+        Args:
+            mock_user: Mock ``User`` with ``is_admin=True`` from conftest.
+            test_config: Test configuration fixture.
+
+        Yields:
+            TestClient: Client whose ``user_authorized`` returns an admin user.
+
+        """
+        app = get_app(test_config)
+
+        category_dao = _async_dao_mock()
+        category_dao.get_all = AsyncMock(return_value=([], 0))
+
+        app.dependency_overrides[user_authorized] = lambda: mock_user
+        app.dependency_overrides[get_category] = lambda: category_dao
+
+        client = TestClient(app)
+        yield client
+
+        app.dependency_overrides.clear()
+
+    def test_admin_passes_admin_required_gate(self, admin_client: TestClient) -> None:
+        """An admin reaches the handler — the gate must not short-circuit with 403."""
+        response = admin_client.get("/api/v1/category")
+        assert response.status_code == 200
+
+
+@pytest.mark.api
+class TestAddressPublicReadsAllowedForNonAdmin:
+    """``GET /address`` and ``GET /address/name/{local_name}`` skip the admin gate."""
+
+    def test_non_admin_can_list_addresses(self, non_admin_client: TestClient) -> None:
+        """Listing addresses must remain available to authenticated non-admin users."""
+        # The injected address DAO is a bare AsyncMock; override its get_all to
+        # return an empty page so the handler can serialize a valid response.
+        from expenses_counter.modules.middlewares.dependencies.daos import get_address as _get_address
+
+        dao = _async_dao_mock()
+        dao.get_all = AsyncMock(return_value=([], 0))
+        non_admin_client.app.dependency_overrides[_get_address] = lambda: dao
+
+        response = non_admin_client.get("/api/v1/address")
+        assert response.status_code == 200
+
+    def test_non_admin_can_look_up_address_by_local_name(self, non_admin_client: TestClient) -> None:
+        """Resolving an address by local name must not require admin privileges."""
+        from sqlalchemy.exc import NoResultFound
+
+        from expenses_counter.modules.middlewares.dependencies.daos import get_address as _get_address
+
+        dao = _async_dao_mock()
+        # 404 is fine — what matters is we are not blocked by ``admin_required``.
+        dao.get_by_address = AsyncMock(side_effect=NoResultFound("Address not found"))
+        non_admin_client.app.dependency_overrides[_get_address] = lambda: dao
+
+        response = non_admin_client.get("/api/v1/address/name/unknown")
+        assert response.status_code == 404

--- a/backend/tests/api/test_user.py
+++ b/backend/tests/api/test_user.py
@@ -346,3 +346,65 @@ class TestPatchMe:
         response = test_client.patch("/api/v1/user", json={"firstName": "x" * 151})
 
         assert response.status_code == 422
+
+
+@pytest.mark.api
+class TestGetAvailablePages:
+    """Test GET /api/v1/user/available-pages endpoint."""
+
+    def _build_client(self, test_config, mock_user_dao, user: MagicMock) -> TestClient:
+        """Wire a ``TestClient`` whose ``user_authorized`` resolves to ``user``."""
+        app = get_app(test_config)
+        app.dependency_overrides[get_user_dao] = lambda: mock_user_dao
+        app.dependency_overrides[user_authorized] = lambda: user
+        return TestClient(app)
+
+    def test_admin_user_sees_admin_pages(self, test_config, mock_user_dao):
+        """Admin users get the admin-only page keys."""
+        admin = MagicMock(spec=User)
+        admin.is_admin = True
+        client = self._build_client(test_config, mock_user_dao, admin)
+
+        try:
+            response = client.get("/api/v1/user/available-pages")
+        finally:
+            client.app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        assert response.json() == ["shops", "products"]
+
+    def test_non_admin_user_sees_empty_list(self, test_config, mock_user_dao):
+        """Non-admin users get no admin-gated page keys."""
+        regular = MagicMock(spec=User)
+        regular.is_admin = False
+        client = self._build_client(test_config, mock_user_dao, regular)
+
+        try:
+            response = client.get("/api/v1/user/available-pages")
+        finally:
+            client.app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_response_differs_between_admin_and_non_admin(self, test_config, mock_user_dao):
+        """The same endpoint must return different payloads for the two roles."""
+        admin = MagicMock(spec=User)
+        admin.is_admin = True
+        regular = MagicMock(spec=User)
+        regular.is_admin = False
+
+        admin_client = self._build_client(test_config, mock_user_dao, admin)
+        try:
+            admin_pages = admin_client.get("/api/v1/user/available-pages").json()
+        finally:
+            admin_client.app.dependency_overrides.clear()
+
+        regular_client = self._build_client(test_config, mock_user_dao, regular)
+        try:
+            regular_pages = regular_client.get("/api/v1/user/available-pages").json()
+        finally:
+            regular_client.app.dependency_overrides.clear()
+
+        assert admin_pages != regular_pages
+        assert set(admin_pages) - set(regular_pages) == {"shops", "products"}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -212,14 +212,34 @@ async def async_db_client(
 def mock_user() -> MagicMock:
     """Return a mock ``User`` for tests that override ``user_authorized``.
 
+    The user is flagged as an admin so requests pass the ``admin_required``
+    gate guarding most ``/api/v1`` routers.
+
     Returns:
-        MagicMock: A mock user with stable ``id``, ``username``, and ``email``.
+        MagicMock: A mock admin user with stable ``id``, ``username``, and ``email``.
 
     """
     user = MagicMock(spec=User)
     user.id = 1
     user.username = "testuser"
     user.email = "test@example.com"
+    user.is_admin = True
+    return user
+
+
+@pytest.fixture
+def mock_non_admin_user() -> MagicMock:
+    """Return a non-admin mock ``User`` for ``admin_required`` rejection tests.
+
+    Returns:
+        MagicMock: A mock user with ``is_admin`` set to ``False``.
+
+    """
+    user = MagicMock(spec=User)
+    user.id = 2
+    user.username = "regular"
+    user.email = "regular@example.com"
+    user.is_admin = False
     return user
 
 
@@ -245,6 +265,7 @@ async def test_user_in_db(
         username="integration-user",
         email="integration@example.com",
         password="integration-password",
+        is_admin=True,
     )
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expenses-counter",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expenses-counter",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expenses-counter",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/navbar/Navbar.tsx
+++ b/frontend/src/components/navbar/Navbar.tsx
@@ -13,7 +13,7 @@ import { Link } from 'react-router';
 import { Image } from '@components/image';
 
 import { default as defaultImage } from './expenses.svg';
-import { Logout } from './Logout';
+import { Logout } from './logout';
 import * as defaultStyle from './style.scss';
 
 const cx = classnames.bind(defaultStyle);
@@ -41,12 +41,6 @@ export function Navbar() {
               <Stack direction="row" spacing={2}>
                 <Link to="/" className={cx('navlink-text')}>
                   <Typography variant="h6">Home</Typography>
-                </Link>
-                <Link to="/shop" className={cx('navlink-text')}>
-                  <Typography variant="h6">Shops</Typography>
-                </Link>
-                <Link to="/product" className={cx('navlink-text')}>
-                  <Typography variant="h6">Products</Typography>
                 </Link>
                 <Link to="/transaction" className={cx('navlink-text')}>
                   <Typography variant="h6">Transactions</Typography>

--- a/frontend/src/components/navbar/logout/Logout.tsx
+++ b/frontend/src/components/navbar/logout/Logout.tsx
@@ -18,7 +18,9 @@ import { Avatar } from '@components/avatar';
 import { useUserAPIClient } from '@services/apiClient/user';
 import { useMainStore } from '@store/main/mainStore';
 
-import * as defaultStyle from './style.scss';
+import * as defaultStyle from '../style.scss';
+
+import type { AvailablePagesType } from './types';
 
 const cx = classnames.bind(defaultStyle);
 
@@ -28,11 +30,23 @@ const cx = classnames.bind(defaultStyle);
  * @returns {JSX.Element | null} MUI Typography that clears the token and navigates to login, or nothing if logged out.
  */
 export function Logout() {
+  const pagesMapping: Record<string, AvailablePagesType> = {
+    shops: {
+      label: 'Shops',
+      path: '/shop',
+    },
+    products: {
+      label: 'Products',
+      path: '/product',
+    },
+  };
+
   const navigate = useNavigate();
 
   const { user, setUser } = useMainStore();
-  const { getUser } = useUserAPIClient();
+  const { getUser, getAvailablePages } = useUserAPIClient();
 
+  const [availablePages, setAvailablePages] = useState<AvailablePagesType[]>([]);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
@@ -45,11 +59,23 @@ export function Logout() {
   };
 
   useEffect(() => {
-    if (user !== null || !Cookies.get('accessToken')) return;
+    if (user !== null && !!Cookies.get('accessToken')) {
+      getAvailablePages().then((pages) => {
+        const newAvailablePages: AvailablePagesType[] = [];
+        pages.forEach((page) => {
+          if (page in pagesMapping) {
+            newAvailablePages.push(pagesMapping[page]);
+          }
+        });
+        setAvailablePages(newAvailablePages);
+      });
+    }
 
-    getUser().then((user) => {
-      setUser(user);
-    });
+    if (user === null && !!Cookies.get('accessToken')) {
+      getUser().then((user) => {
+        setUser(user);
+      });
+    }
   }, [user, Cookies.get('accessToken')]);
 
   /** Removes session cookie and redirects to the login route. */
@@ -111,6 +137,18 @@ export function Logout() {
         >
           Profile
         </MenuItem>
+        {availablePages.length > 0 && <Divider />}
+        {availablePages.map((page, index) => (
+          <MenuItem
+            key={index}
+            onClick={() => {
+              handleClose();
+              navigate(page.path);
+            }}
+          >
+            {page.label}
+          </MenuItem>
+        ))}
         <Divider />
         <MenuItem onClick={handleLogout}>Logout</MenuItem>
         <Divider />

--- a/frontend/src/components/navbar/logout/Logout.tsx
+++ b/frontend/src/components/navbar/logout/Logout.tsx
@@ -20,7 +20,7 @@ import { useMainStore } from '@store/main/mainStore';
 
 import * as defaultStyle from '../style.scss';
 
-import type { AvailablePagesType } from './types';
+import type { AvailablePageType } from './types';
 
 const cx = classnames.bind(defaultStyle);
 
@@ -30,7 +30,7 @@ const cx = classnames.bind(defaultStyle);
  * @returns {JSX.Element | null} MUI Typography that clears the token and navigates to login, or nothing if logged out.
  */
 export function Logout() {
-  const pagesMapping: Record<string, AvailablePagesType> = {
+  const pagesMapping: Record<string, AvailablePageType> = {
     shops: {
       label: 'Shops',
       path: '/shop',
@@ -46,7 +46,7 @@ export function Logout() {
   const { user, setUser } = useMainStore();
   const { getUser, getAvailablePages } = useUserAPIClient();
 
-  const [availablePages, setAvailablePages] = useState<AvailablePagesType[]>([]);
+  const [availablePages, setAvailablePages] = useState<AvailablePageType[]>([]);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
@@ -61,7 +61,7 @@ export function Logout() {
   useEffect(() => {
     if (user !== null && !!Cookies.get('accessToken')) {
       getAvailablePages().then((pages) => {
-        const newAvailablePages: AvailablePagesType[] = [];
+        const newAvailablePages: AvailablePageType[] = [];
         pages.forEach((page) => {
           if (page in pagesMapping) {
             newAvailablePages.push(pagesMapping[page]);

--- a/frontend/src/components/navbar/logout/index.ts
+++ b/frontend/src/components/navbar/logout/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Barrel module for the logout component: re-exports {@link Logout} from `./Logout`.
+ *
+ * @module components/navbar/logout/index
+ */
+
+import { Logout } from './Logout';
+
+export { Logout };

--- a/frontend/src/components/navbar/logout/types.ts
+++ b/frontend/src/components/navbar/logout/types.ts
@@ -8,7 +8,7 @@
  * @property {string} label - Text shown in the menu for this entry.
  * @property {string} path - Client route path (e.g. `/shop`) when the item is chosen.
  */
-export type AvailablePagesType = {
+export type AvailablePageType = {
   label: string;
   path: string;
 };

--- a/frontend/src/components/navbar/logout/types.ts
+++ b/frontend/src/components/navbar/logout/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Type definitions for navbar logout menu navigation entries.
+ */
+
+/**
+ * Label and route for a page linked from the user menu.
+ *
+ * @property {string} label - Text shown in the menu for this entry.
+ * @property {string} path - Client route path (e.g. `/shop`) when the item is chosen.
+ */
+export type AvailablePagesType = {
+  label: string;
+  path: string;
+};

--- a/frontend/src/services/apiClient/user/client.ts
+++ b/frontend/src/services/apiClient/user/client.ts
@@ -44,5 +44,14 @@ export const useUserAPIClient = () => {
         return response.data;
       });
     },
+    /**
+     * Fetches the available pages (`GET /api/v1/user/available-pages`).
+     *
+     * @returns {Promise<string[]>} Available pages.
+     */
+    getAvailablePages: async () => {
+      const response = await apiClientInstance.get<string[]>('/api/v1/user/available-pages');
+      return response.data;
+    },
   };
 };


### PR DESCRIPTION
This pull request introduces role-based access control for admin-only resources in both the backend and frontend, and updates the user interface to dynamically show navigation options based on user permissions. It also includes version bumps for both backend and frontend packages.

**Backend: Role-based access control and new endpoint**

* Restricted access to the `address`, `category`, `product`, and `shop` API routes to admin users only by replacing the `user_authorized` dependency with `admin_required` in their respective routers. [[1]](diffhunk://#diff-50d79dfbea13c52fd7b94875dbe961a3cad2f0af215eaa0523d0626697b3a02cR24-L25) [[2]](diffhunk://#diff-50d79dfbea13c52fd7b94875dbe961a3cad2f0af215eaa0523d0626697b3a02cL40-R40) [[3]](diffhunk://#diff-90dd37eb38f626bdc315c6626bb8db21a4eda74f35c8c739773500b366739ae9R24-L25) [[4]](diffhunk://#diff-90dd37eb38f626bdc315c6626bb8db21a4eda74f35c8c739773500b366739ae9L42-R42) [[5]](diffhunk://#diff-045030ea745697b9ab77da714cae159311741ec88361b55067609a10b2ca6439R34-L35) [[6]](diffhunk://#diff-045030ea745697b9ab77da714cae159311741ec88361b55067609a10b2ca6439L50-R50) [[7]](diffhunk://#diff-f1305728e46a3de76df927d7bd7c61ae9e7ef6285aa32930b40950d8309c8b47R22-L23) [[8]](diffhunk://#diff-f1305728e46a3de76df927d7bd7c61ae9e7ef6285aa32930b40950d8309c8b47L38-R38)
* Added a new endpoint `GET /user/available-pages` to return the list of page keys the authenticated user can access, enabling the frontend to adjust navigation options based on user role. [[1]](diffhunk://#diff-31c013d3a45a484e33ebb3b1d954ee5ebdfb7d55899a31309cd40a577f60aa07R10) [[2]](diffhunk://#diff-31c013d3a45a484e33ebb3b1d954ee5ebdfb7d55899a31309cd40a577f60aa07R141-R165)
* Updated Alembic migration defaults for boolean columns `is_admin` and `is_active` to use `"0"` and `"1"` instead of `"false"` and `"true"` for compatibility.

**Frontend: Dynamic navigation and code organization**

* Updated the navbar to remove hardcoded "Shops" and "Products" links, and instead display navigation options in the user menu based on available pages fetched from the backend. This uses a new `AvailablePagesType` type and mapping logic. [[1]](diffhunk://#diff-636121dc0d7839e7eec334d40caa84230be337df22a476a7ce557bf86d399baeL16-R16) [[2]](diffhunk://#diff-636121dc0d7839e7eec334d40caa84230be337df22a476a7ce557bf86d399baeL45-L50) [[3]](diffhunk://#diff-8b874ba9088d171d7c002f158dacd4304b181aa63fc753579600401e65e5a00bL21-R23) [[4]](diffhunk://#diff-8b874ba9088d171d7c002f158dacd4304b181aa63fc753579600401e65e5a00bR33-R49) [[5]](diffhunk://#diff-8b874ba9088d171d7c002f158dacd4304b181aa63fc753579600401e65e5a00bL48-R78) [[6]](diffhunk://#diff-8b874ba9088d171d7c002f158dacd4304b181aa63fc753579600401e65e5a00bR140-R151) [[7]](diffhunk://#diff-4aa3dfdc50646d78e19b60b34c228006b4f39a323d026eb85bb5b3eba2a1d0b7R1-R14)
* Added a new API client method `getAvailablePages` to fetch available pages for the current user.
* Refactored the `Logout` component into a subdirectory and added a barrel export for improved code organization. [[1]](diffhunk://#diff-8b874ba9088d171d7c002f158dacd4304b181aa63fc753579600401e65e5a00bL21-R23) [[2]](diffhunk://#diff-f6bd98db6d5c351d2ebd152a205acc078855928b8fd6fc5839c645ee900d5b14R1-R9)
* Bumped frontend package version to `1.2.4` and backend package version to `1.3.2`. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[3]](diffhunk://#diff-a699aa25d7ebbb5f884bdfcd7b6487d5a308fedf49b5d0a5b35ee1560d32d1a6L3-R3)