### PR TITLE
fix: Fix create update transaction date

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expenses-counter",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expenses-counter",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expenses-counter",
   "private": true,
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/transaction/LeftSide.tsx
+++ b/frontend/src/pages/transaction/LeftSide.tsx
@@ -39,7 +39,15 @@ export function LeftSide() {
 
   const currentDate = useMemo(() => {
     const dateParam = searchParams.get('date');
-    return dateParam ? dayjs(dateParam) : dayjs();
+    const payload = dateParam ? dayjs(dateParam) : dayjs();
+    if (!payload.isValid()) {
+      setSearchParams((previous) => {
+        previous.set('date', dayjs().format('YYYY-MM-DD'));
+        return previous;
+      });
+      return dayjs();
+    }
+    return payload;
   }, [searchParams]);
 
   /** Fetches every page of transactions between the month's start and end (inclusive) and replaces the store list. */

--- a/frontend/src/pages/transaction/createTransaction/CreateTransaction.tsx
+++ b/frontend/src/pages/transaction/createTransaction/CreateTransaction.tsx
@@ -9,8 +9,9 @@ import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
-import { useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import dayjs from 'dayjs';
+import { useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 
 import { AsyncInput } from '@components/asyncInput';
 import { Input } from '@components/input';
@@ -30,10 +31,11 @@ import { useTransactionStore } from '@store/transaction';
  */
 export function CreateTransaction() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { transactionId } = useParams();
   const formRef = useRef<HTMLFormElement>(null);
 
-  const { currentTransaction, currentDate } = useTransactionStore();
+  const { currentTransaction } = useTransactionStore();
   const { products, setProducts } = useProductStore();
   const { addresses, setAddresses } = useShopStore();
 
@@ -47,6 +49,11 @@ export function CreateTransaction() {
     currentTransaction?.product ?? null
   );
 
+  const currentDate = useMemo(() => {
+    const dateParam = searchParams.get('date');
+    return dateParam ? dayjs(dateParam) : dayjs();
+  }, [searchParams]);
+
   /** Builds payload from the form and store date, then POST (navigate to new id) or PUT when `transactionId` is set. */
   const clickHandler = async () => {
     const formData = new FormData(formRef.current as HTMLFormElement);
@@ -58,7 +65,7 @@ export function CreateTransaction() {
     if (transactionId === undefined) {
       try {
         const response = await postTransaction(data);
-        navigate(`/transaction/${response.id}`);
+        navigate({ pathname: `/transaction/${response.id}`, search: searchParams.toString() });
       } catch (error) {
         console.error(error);
       }
@@ -70,7 +77,7 @@ export function CreateTransaction() {
   /** Deletes the transaction for the route id and navigates back to the transaction list. */
   const deleteHandler = async () => {
     await deleteTransaction(parseInt(transactionId as string));
-    navigate('/transaction');
+    navigate({ pathname: '/transaction', search: searchParams.toString() });
   };
 
   return (

--- a/frontend/src/pages/transaction/createTransaction/CreateTransaction.tsx
+++ b/frontend/src/pages/transaction/createTransaction/CreateTransaction.tsx
@@ -51,7 +51,11 @@ export function CreateTransaction() {
 
   const currentDate = useMemo(() => {
     const dateParam = searchParams.get('date');
-    return dateParam ? dayjs(dateParam) : dayjs();
+    const payload = dateParam ? dayjs(dateParam) : dayjs();
+    if (!payload.isValid()) {
+      return dayjs();
+    }
+    return payload;
   }, [searchParams]);
 
   /** Builds payload from the form and store date, then POST (navigate to new id) or PUT when `transactionId` is set. */


### PR DESCRIPTION
This pull request updates the transaction creation page to improve how the transaction date is handled and to ensure that URL search parameters (such as a pre-selected date) are preserved during navigation. The application version is also bumped to `1.2.5`.

**Improvements to transaction date handling and navigation:**

* The `CreateTransaction` page now reads the `date` parameter from the URL search params and uses it as the default transaction date, falling back to the current date if not present. This makes it possible to pre-fill the date via the URL. [[1]](diffhunk://#diff-5d7ce01d6e0c1d4a664f0214e7982929af03b5e55786129797243f92792540ffL12-R14) [[2]](diffhunk://#diff-5d7ce01d6e0c1d4a664f0214e7982929af03b5e55786129797243f92792540ffR34-R38) [[3]](diffhunk://#diff-5d7ce01d6e0c1d4a664f0214e7982929af03b5e55786129797243f92792540ffR52-R56)
* All navigations from the transaction creation page now preserve existing search parameters, ensuring that context (like the selected date) is not lost when redirecting after creating or deleting a transaction. [[1]](diffhunk://#diff-5d7ce01d6e0c1d4a664f0214e7982929af03b5e55786129797243f92792540ffL61-R68) [[2]](diffhunk://#diff-5d7ce01d6e0c1d4a664f0214e7982929af03b5e55786129797243f92792540ffL73-R80)

**Version update:**

* Application version updated from `1.2.4` to `1.2.5` in `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)